### PR TITLE
list interface update

### DIFF
--- a/projects/ui-framework/src/lib/form-elements/lists/list-change/list-change.service.spec.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/list-change/list-change.service.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+import { SelectGroupOption } from '../list.interface';;
+import { ListChangeService } from './list-change.service';
+
+describe('ListChangeService', () => {
+  let listChangeServive: ListChangeService;
+  let optionsMock: SelectGroupOption[];
+
+  beforeEach(() => {
+    optionsMock = [
+      {
+        groupName: 'Basic Info',
+        options: [
+          { value: 'Basic Info 1', id: 1, selected: true, },
+          { value: 'Basic Info 2', id: 2, selected: false, },
+        ],
+      },
+      {
+        groupName: 'Personal',
+        options: [
+          { value: 'Personal 1', id: 11, selected: false, },
+          { value: 'Personal 2', id: 12, selected: false, },
+        ],
+      },
+    ];
+
+    TestBed.configureTestingModule({
+      providers: [
+        ListChangeService,
+      ]
+    });
+
+    listChangeServive = TestBed.get(ListChangeService);
+  });
+
+  describe('getListChange', () => {
+    it('should return listChange class', () => {
+      expect(1 === 1).toBeTruthy();
+    });
+  });
+});

--- a/projects/ui-framework/src/lib/form-elements/lists/list-change/list-change.service.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/list-change/list-change.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { ListChange } from './list-change';
+import { SelectGroupOption } from '../list.interface';
+import { assign, chain, includes, map } from 'lodash';
+
+@Injectable()
+export class ListChangeService {
+
+  getListChange(
+    options: SelectGroupOption[],
+    selectedIdsMap: (string | number)[],
+  ): ListChange {
+    const currentOptions = this.getCurrentSelectGroupOptions(options, selectedIdsMap);
+    return new ListChange(currentOptions);
+  }
+
+  private getCurrentSelectGroupOptions(
+    options: SelectGroupOption[],
+    selectedIdsMap: (string | number)[],
+  ): SelectGroupOption[] {
+    return map(options, g => assign({}, g, {
+      options: map(g.options, o => assign({}, o, {
+        selected: includes(selectedIdsMap, o.id),
+      })),
+    }));
+  }
+}

--- a/projects/ui-framework/src/lib/form-elements/lists/list-change/list-change.spec.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/list-change/list-change.spec.ts
@@ -1,0 +1,46 @@
+import { SelectGroupOption } from '../list.interface';
+import { ListChange } from './list-change';
+
+describe('ListChange', () => {
+  let listChange: ListChange;
+  let optionsMock: SelectGroupOption[];
+
+  beforeEach(() => {
+    optionsMock = [
+      {
+        groupName: 'Basic Info',
+        options: [
+          { value: 'Basic Info 1', id: 1, selected: false, },
+          { value: 'Basic Info 2', id: 2, selected: false, },
+        ],
+      },
+      {
+        groupName: 'Personal',
+        options: [
+          { value: 'Personal 1', id: 11, selected: false, },
+          { value: 'Personal 2', id: 12, selected: false, },
+        ],
+      },
+    ];
+  });
+
+  describe('getSelectGroupOptions', () => {
+    it('should return getSelectGroupOptions model', () => {
+      listChange = new ListChange(optionsMock);
+      expect(listChange.getSelectGroupOptions()).toEqual(optionsMock);
+    });
+  });
+
+  describe('getSelectedIds', () => {
+    it('should return empty array when non are selected', () => {
+      listChange = new ListChange(optionsMock);
+      expect(listChange.getSelectedIds()).toEqual([]);
+    });
+    it('should return flat ids map', () => {
+      optionsMock[0].options[0].selected = true;
+      optionsMock[1].options[0].selected = true;
+      listChange = new ListChange(optionsMock);
+      expect(listChange.getSelectedIds()).toEqual([1, 11]);
+    });
+  });
+});

--- a/projects/ui-framework/src/lib/form-elements/lists/list-change/list-change.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/list-change/list-change.ts
@@ -1,0 +1,24 @@
+import { chain } from 'lodash';
+import { SelectGroupOption } from '../list.interface';
+
+export class ListChange {
+  private readonly selectGroupOptions: SelectGroupOption[];
+
+  constructor(
+    selectedGroupOptionsSrc: SelectGroupOption[],
+  ) {
+    this.selectGroupOptions = selectedGroupOptionsSrc;
+  }
+
+  getSelectGroupOptions(): SelectGroupOption[] {
+    return this.selectGroupOptions;
+  }
+
+  getSelectedIds(): (number | string)[] {
+    return chain(this.selectGroupOptions)
+      .flatMap('options')
+      .filter(o => o.selected)
+      .flatMap('id')
+      .value();
+  }
+}

--- a/projects/ui-framework/src/lib/form-elements/lists/list-element.abstract.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/list-element.abstract.ts
@@ -34,14 +34,17 @@ export abstract class BaseListElement implements OnInit, OnDestroy, AfterViewIni
       .subscribe((e: KeyboardEvent) => {
         switch (e.code) {
           case(NavigationKeys.down):
-            this.focusIndex = this.listKeyboardService.getNextFocusIndex(NavigationKeys.down, this.focusIndex, this.listOptions.length);
+            this.focusIndex = this.listKeyboardService
+              .getNextFocusIndex(NavigationKeys.down, this.focusIndex, this.listOptions.length);
             this.focusOption = this.listOptions[this.focusIndex];
             this.vScroll.scrollToIndex(this.listKeyboardService.getScrollToIndex(this.focusIndex, this.maxHeight));
             break;
           case(NavigationKeys.up):
-            this.focusIndex = this.listKeyboardService.getNextFocusIndex(NavigationKeys.up, this.focusIndex, this.listOptions.length);
+            this.focusIndex = this.listKeyboardService
+              .getNextFocusIndex(NavigationKeys.up, this.focusIndex, this.listOptions.length);
             this.focusOption = this.listOptions[this.focusIndex];
-            this.vScroll.scrollToIndex(this.listKeyboardService.getScrollToIndex(this.focusIndex, this.maxHeight));
+            this.vScroll.scrollToIndex(this.listKeyboardService
+              .getScrollToIndex(this.focusIndex, this.maxHeight));
             break;
           case(NavigationKeys.enter):
             this.focusOption.isPlaceHolder

--- a/projects/ui-framework/src/lib/form-elements/lists/list-option/list-option.component.scss
+++ b/projects/ui-framework/src/lib/form-elements/lists/list-option/list-option.component.scss
@@ -1,6 +1,7 @@
 :host {
   display: inline-block;
   vertical-align: middle;
+  cursor: default;
   .comp-prefix, .value {
     display: inline-block;
     vertical-align: middle;

--- a/projects/ui-framework/src/lib/form-elements/lists/list-service/list-model.service.spec.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/list-service/list-model.service.spec.ts
@@ -11,15 +11,15 @@ describe('ListModelService', () => {
       {
         groupName: 'Basic Info',
         options: [
-          { value: 'Basic Info 1', id: 1 },
-          { value: 'Basic Info 2', id: 2 },
+          { value: 'Basic Info 1', id: 1, selected: true, },
+          { value: 'Basic Info 2', id: 2, selected: false, },
         ],
       },
       {
         groupName: 'Personal',
         options: [
-          { value: 'Personal 1', id: 11 },
-          { value: 'Personal 2', id: 12 },
+          { value: 'Personal 1', id: 11, selected: false, },
+          { value: 'Personal 2', id: 12, selected: false, },
         ],
       },
     ];
@@ -71,14 +71,14 @@ describe('ListModelService', () => {
           id: 1,
           groupName: 'Basic Info',
           isPlaceHolder: false,
-          selected: null,
+          selected: true,
         },
         {
           value: 'Basic Info 2',
           id: 2,
           groupName: 'Basic Info',
           isPlaceHolder: false,
-          selected: null,
+          selected: false,
         },
         {
           isPlaceHolder: true,
@@ -92,14 +92,14 @@ describe('ListModelService', () => {
           id: 11,
           groupName: 'Personal',
           isPlaceHolder: false,
-          selected: null,
+          selected: false,
         },
         {
           value: 'Personal 2',
           id: 12,
           groupName: 'Personal',
           isPlaceHolder: false,
-          selected: null,
+          selected: false,
         },
       ]);
     });
@@ -267,6 +267,20 @@ describe('ListModelService', () => {
           selected: null,
         },
       ]);
+    });
+  });
+
+  describe('getSelectedIdsMap', () => {
+    it('should return empty array when no option is selected', () => {
+      optionsMock[0].options[0].selected = false;
+      const selectedIdsMap = listModelService.getSelectedIdsMap(optionsMock);
+      expect(selectedIdsMap).toEqual([]);
+    });
+    it('should return array of selected Ids', () => {
+      optionsMock[0].options[0].selected = true;
+      optionsMock[1].options[0].selected = true;
+      const selectedIdsMap = listModelService.getSelectedIdsMap(optionsMock);
+      expect(selectedIdsMap).toEqual([1, 11]);
     });
   });
 });

--- a/projects/ui-framework/src/lib/form-elements/lists/list.interface.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/list.interface.ts
@@ -16,12 +16,14 @@ export interface ListOption {
 
 export interface SelectGroupOption {
   groupName: string;
-  options?: SelectOption[];
+  key?: string,
+  options: SelectOption[];
 }
 
 export interface SelectOption {
   value: string;
   id: number | string;
+  selected: boolean;
   prefixComponent?: ListComponentPrefix;
 }
 

--- a/projects/ui-framework/src/lib/form-elements/lists/multi-list/multi-list.component.spec.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/multi-list/multi-list.component.spec.ts
@@ -1,6 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { MatFormFieldModule, MatIconModule, MatInputModule, MatPseudoCheckboxModule, MatTooltipModule } from '@angular/material';
+import {
+  MatFormFieldModule, MatIconModule, MatInputModule, MatPseudoCheckboxModule, MatTooltipModule,
+} from '@angular/material';
 import { CommonModule } from '@angular/common';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { SearchModule } from '../../../navigation/search/search.module';
@@ -15,6 +17,7 @@ import { MultiListComponent } from './multi-list.component';
 import { FiltersModule } from '../../../services/filters/filters.module';
 import { ListOptionModule } from '../list-option/list-option.module';
 import { ListKeyboardService } from '../list-service/list-keyboard.service';
+import { ListChangeService } from '../list-change/list-change.service';
 
 describe('MultiListComponent', () => {
   let component: MultiListComponent;
@@ -26,15 +29,15 @@ describe('MultiListComponent', () => {
       {
         groupName: 'Basic Info Header',
         options: [
-          { value: 'Basic Info 1', id: 1 },
-          { value: 'Basic Info 2', id: 2 },
+          { value: 'Basic Info 1', id: 1, selected: true },
+          { value: 'Basic Info 2', id: 2, selected: false },
         ]
       },
       {
         groupName: 'Personal Header',
         options: [
-          { value: 'Personal 1', id: 11 },
-          { value: 'Personal 2', id: 12 },
+          { value: 'Personal 1', id: 11, selected: false },
+          { value: 'Personal 2', id: 12, selected: false },
         ]
       }
     ];
@@ -45,6 +48,7 @@ describe('MultiListComponent', () => {
       ],
       providers: [
         ListModelService,
+        ListChangeService,
         ListKeyboardService,
       ],
       imports: [
@@ -83,6 +87,10 @@ describe('MultiListComponent', () => {
   }));
 
   describe('OnChanges', () => {
+    it('should create selectedIdsMap based on options', () => {
+      component.ngOnChanges({});
+      expect(component.selectedIdsMap).toEqual([1]);
+    });
     it('should create headerModel based on options', () => {
       component.ngOnChanges({});
       expect(component.listHeaders).toEqual([
@@ -135,7 +143,7 @@ describe('MultiListComponent', () => {
           id: 11,
           groupName: 'Personal Header',
           isPlaceHolder: false,
-          selected: true
+          selected: false
         },
         {
           value: 'Personal 2',
@@ -154,14 +162,14 @@ describe('MultiListComponent', () => {
       const options = fixture.debugElement.queryAll(By.css('.option'));
       expect(options.length).toEqual(4);
     });
-    it('should set the checkbox of options where (id=1,11) as checked', () => {
+    it('should set the checkbox of options where (id=1) as checked', () => {
       const checkboxes = fixture.debugElement.queryAll(By.css('.option .checkbox'));
       expect(checkboxes[0].nativeElement.getAttribute('ng-reflect-state')).toEqual('checked');
-      expect(checkboxes[2].nativeElement.getAttribute('ng-reflect-state')).toEqual('checked');
     });
-    it('should set the checkbox of options where (id=2,12) as unchecked', () => {
+    it('should set the checkbox of options where (id=2,11,12) as unchecked', () => {
       const checkboxes = fixture.debugElement.queryAll(By.css('.option .checkbox'));
       expect(checkboxes[1].nativeElement.getAttribute('ng-reflect-state')).toEqual('unchecked');
+      expect(checkboxes[2].nativeElement.getAttribute('ng-reflect-state')).toEqual('unchecked');
       expect(checkboxes[3].nativeElement.getAttribute('ng-reflect-state')).toEqual('unchecked');
     });
     it('should rerender lists if simpleChanges includes options', () => {
@@ -238,23 +246,23 @@ describe('MultiListComponent', () => {
         {
           groupName: 'Basic Info Header',
           options: [
-            { value: 'Basic Info 1', id: 1 },
-            { value: 'Basic Info 2', id: 2 },
-            { value: 'Basic Info 3', id: 3 },
-            { value: 'Basic Info 4', id: 4 },
-            { value: 'Basic Info 5', id: 5 },
-            { value: 'Basic Info 6', id: 6 },
+            { value: 'Basic Info 1', id: 1, selected: false },
+            { value: 'Basic Info 2', id: 2, selected: false },
+            { value: 'Basic Info 3', id: 3, selected: false },
+            { value: 'Basic Info 4', id: 4, selected: false },
+            { value: 'Basic Info 5', id: 5, selected: false },
+            { value: 'Basic Info 6', id: 6, selected: false },
           ]
         },
         {
           groupName: 'Personal Header',
           options: [
-            { value: 'Personal 1', id: 11 },
-            { value: 'Personal 2', id: 12 },
-            { value: 'Personal 3', id: 13 },
-            { value: 'Personal 4', id: 14 },
-            { value: 'Personal 5', id: 15 },
-            { value: 'Personal 6', id: 16 },
+            { value: 'Personal 1', id: 11, selected: false },
+            { value: 'Personal 2', id: 12, selected: false },
+            { value: 'Personal 3', id: 13, selected: false },
+            { value: 'Personal 4', id: 14, selected: false },
+            { value: 'Personal 5', id: 15, selected: false },
+            { value: 'Personal 6', id: 16, selected: false },
           ]
         }
       ];
@@ -293,28 +301,28 @@ describe('MultiListComponent', () => {
       const searchEl = fixture.debugElement.query(By.css('b-search'));
       expect(searchEl).toBeFalsy();
     });
-    it('should display search field also when listOptions is empty if total options is greater the DISPLAY_SEARCH_OPTION_NUM', () => {
+    it('should display search field when listOptions=empty if total options>DISPLAY_SEARCH_OPTION_NUM', () => {
       const testOptionsMock = [
         {
           groupName: 'Basic Info Header',
           options: [
-            { value: 'Basic Info 1', id: 1 },
-            { value: 'Basic Info 2', id: 2 },
-            { value: 'Basic Info 3', id: 3 },
-            { value: 'Basic Info 4', id: 4 },
-            { value: 'Basic Info 5', id: 5 },
-            { value: 'Basic Info 6', id: 6 },
+            { value: 'Basic Info 1', id: 1, selected: false },
+            { value: 'Basic Info 2', id: 2, selected: false },
+            { value: 'Basic Info 3', id: 3, selected: false },
+            { value: 'Basic Info 4', id: 4, selected: false },
+            { value: 'Basic Info 5', id: 5, selected: false },
+            { value: 'Basic Info 6', id: 6, selected: false },
           ]
         },
         {
           groupName: 'Personal Header',
           options: [
-            { value: 'Personal 1', id: 11 },
-            { value: 'Personal 2', id: 12 },
-            { value: 'Personal 3', id: 13 },
-            { value: 'Personal 4', id: 14 },
-            { value: 'Personal 5', id: 15 },
-            { value: 'Personal 6', id: 16 },
+            { value: 'Personal 1', id: 11, selected: false },
+            { value: 'Personal 2', id: 12, selected: false },
+            { value: 'Personal 3', id: 13, selected: false },
+            { value: 'Personal 4', id: 14, selected: false },
+            { value: 'Personal 5', id: 15, selected: false },
+            { value: 'Personal 6', id: 16, selected: false },
           ]
         }
       ];
@@ -358,15 +366,16 @@ describe('MultiListComponent', () => {
   });
 
   describe('option click', () => {
-    it('should update value when option is clicked with the option id', () => {
+    it('should update selectionMap on option select with the option id', () => {
       const options = fixture.debugElement.queryAll(By.css('.option'));
       options[3].triggerEventHandler('click', null);
-      expect(component.value).toEqual([1, 11, 12]);
+      expect(component.selectedIdsMap).toEqual([1, 12]);
     });
     it('should emit event when selecting an option', () => {
       const options = fixture.debugElement.queryAll(By.css('.option'));
       options[3].triggerEventHandler('click', null);
-      expect(component.selectChange.emit).toHaveBeenCalledWith([1, 11, 12]);
+      const listChange = component['listChangeService'].getListChange(component.options, [1, 12]);
+      expect(component.selectChange.emit).toHaveBeenCalledWith(listChange);
     });
   });
 
@@ -375,16 +384,16 @@ describe('MultiListComponent', () => {
       const headerCheckbox = fixture.debugElement.queryAll(By.css('.header .checkbox'));
       headerCheckbox[0].triggerEventHandler('click', null);
       fixture.autoDetectChanges();
-      expect(component.value).toEqual([1, 11, 2]);
+      expect(component.selectedIdsMap).toEqual([1, 2]);
     });
     it('should deselect all options in group when deselecting header', () => {
       const headerCheckbox = fixture.debugElement.queryAll(By.css('.header .checkbox'));
       headerCheckbox[0].triggerEventHandler('click', null);
       fixture.autoDetectChanges();
-      expect(component.value).toEqual([1, 11, 2]);
+      expect(component.selectedIdsMap).toEqual([1, 2]);
       headerCheckbox[0].triggerEventHandler('click', null);
       fixture.autoDetectChanges();
-      expect(component.value).toEqual([11]);
+      expect(component.selectedIdsMap).toEqual([]);
     });
     it('should not update options model when header is collapsed', () => {
       const expectedHeaderModel = [
@@ -421,7 +430,7 @@ describe('MultiListComponent', () => {
           id: 11,
           groupName: 'Personal Header',
           isPlaceHolder: false,
-          selected: true
+          selected: false
         },
         {
           value: 'Personal 2',
@@ -446,7 +455,36 @@ describe('MultiListComponent', () => {
       const headerCheckbox = fixture.debugElement.queryAll(By.css('.header .checkbox'));
       headerCheckbox[0].triggerEventHandler('click', null);
       fixture.autoDetectChanges();
-      expect(component.selectChange.emit).toHaveBeenCalledWith([1, 11, 2]);
+      const listChange = component['listChangeService'].getListChange(component.options, [1, 2]);
+      expect(component.selectChange.emit).toHaveBeenCalledWith(listChange);
+    });
+  });
+
+  describe('singleList listChange class', () => {
+    let listChange;
+    beforeEach(() => {
+      listChange = component['listChangeService'].getListChange(component.options, [1, 12]);
+    });
+    it('should return updated options model', () => {
+      expect(listChange.getSelectGroupOptions()).toEqual([
+        {
+          groupName: 'Basic Info Header',
+          options: [
+            { value: 'Basic Info 1', id: 1, selected: true },
+            { value: 'Basic Info 2', id: 2, selected: false },
+          ],
+        },
+        {
+          groupName: 'Personal Header',
+          options: [
+            { value: 'Personal 1', id: 11, selected: false },
+            { value: 'Personal 2', id: 12, selected: true },
+          ]
+        }
+      ]);
+    });
+    it('should return selectedId', () => {
+      expect(listChange.getSelectedIds()).toEqual([1, 12]);
     });
   });
 

--- a/projects/ui-framework/src/lib/form-elements/lists/multi-list/multi-list.component.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/multi-list/multi-list.component.ts
@@ -1,12 +1,14 @@
 import { Component, EventEmitter, Input, OnChanges, Output, Renderer2, SimpleChanges } from '@angular/core';
 import { ListModelService } from '../list-service/list-model.service';
-import { chain, filter, flatMap } from 'lodash';
+import { cloneDeep, flatMap, chain } from 'lodash';
 import { ListHeader, ListOption, SelectGroupOption } from '../list.interface';
 import { BaseListElement } from '../list-element.abstract';
 import { CheckboxStates } from '../../checkbox/checkbox.component';
 import has from 'lodash/has';
 import { DISPLAY_SEARCH_OPTION_NUM } from '../list.consts';
 import { ListKeyboardService } from '../list-service/list-keyboard.service';
+import { ListChangeService } from '../list-change/list-change.service';
+import { ListChange } from '../list-change/list-change';
 
 @Component({
   selector: 'b-multi-list',
@@ -17,7 +19,6 @@ export class MultiListComponent extends BaseListElement implements OnChanges {
 
   @Input() options: SelectGroupOption[];
   @Input() maxHeight = this.listElHeight * 8;
-  @Input() value: (number | string)[] = [];
   @Input() showSingleGroupHeader = false;
   @Output() selectChange: EventEmitter<any> = new EventEmitter<any>();
 
@@ -25,11 +26,13 @@ export class MultiListComponent extends BaseListElement implements OnChanges {
   shouldDisplaySearch = false;
   searchValue: string;
   filteredOptions: SelectGroupOption[];
-
   checkboxState = CheckboxStates;
+
+  selectedIdsMap: (string | number)[];
 
   constructor(
     private listModelService: ListModelService,
+    private listChangeService: ListChangeService,
     renderer: Renderer2,
     listKeyboardService: ListKeyboardService,
   ) {
@@ -38,10 +41,10 @@ export class MultiListComponent extends BaseListElement implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (this.shouldResetModel(changes)) {
-      this.value = has(changes, 'value') ? changes.value.currentValue : this.value;
       this.options = changes.options.currentValue;
+      this.selectedIdsMap = this.getSelectedIdsMap();
       this.noGroupHeaders = this.options.length === 1 && !this.showSingleGroupHeader;
-      this.filteredOptions = this.options;
+      this.filteredOptions = cloneDeep(this.options);
       this.shouldDisplaySearch = flatMap(this.options, 'options').length > DISPLAY_SEARCH_OPTION_NUM;
       this.updateLists();
     }
@@ -59,30 +62,32 @@ export class MultiListComponent extends BaseListElement implements OnChanges {
     header.isCollapsed = !header.isCollapsed;
     this.listOptions = this.listModelService
       .getOptionsModel(this.filteredOptions, this.listHeaders, this.noGroupHeaders);
-    this.listModelService.setSelectedOptions(this.listHeaders, this.listOptions, this.value);
+    this.listModelService.setSelectedOptions(this.listHeaders, this.listOptions, this.selectedIdsMap);
   }
 
   headerSelect(header: ListHeader): void {
     header.selected = !header.selected;
-    const groupOptionsIds = chain(this.filteredOptions)
+    const groupOptionsIds = chain(this.options)
       .filter(group => group.groupName === header.groupName)
       .flatMap('options')
       .flatMap('id')
       .value();
-    this.value = header.selected
-      ? chain(this.value).concat(groupOptionsIds).uniq().value()
-      : chain(this.value).difference(groupOptionsIds).value();
-    this.listModelService.setSelectedOptions(this.listHeaders, this.listOptions, this.value);
-    this.selectChange.emit(this.value);
+    this.selectedIdsMap = header.selected
+      ? chain(this.selectedIdsMap).concat(groupOptionsIds).uniq().value()
+      : chain(this.selectedIdsMap).difference(groupOptionsIds).value();
+    this.listModelService.setSelectedOptions(this.listHeaders, this.listOptions, this.selectedIdsMap);
+
+    this.emitChange();
   }
 
   optionClick(selectedOption: ListOption): void {
     selectedOption.selected = !selectedOption.selected;
-    this.value = selectedOption.selected
-      ? chain(this.value).concat(selectedOption.id).uniq().value()
-      : chain(this.value).difference([selectedOption.id]).value();
-    this.listModelService.setSelectedOptions(this.listHeaders, this.listOptions, this.value);
-    this.selectChange.emit(this.value);
+    this.selectedIdsMap = selectedOption.selected
+      ? chain(this.selectedIdsMap).concat(selectedOption.id).uniq().value()
+      : chain(this.selectedIdsMap).difference([selectedOption.id]).value();
+    this.listModelService.setSelectedOptions(this.listHeaders, this.listOptions, this.selectedIdsMap);
+
+    this.emitChange();
   }
 
   searchChange(s: string): void {
@@ -91,11 +96,24 @@ export class MultiListComponent extends BaseListElement implements OnChanges {
     this.updateLists();
   }
 
+  getListChange(): ListChange {
+    return this.listChangeService.getListChange(this.options, this.selectedIdsMap);
+  }
+
   private updateLists(): void {
     this.listHeaders = this.listModelService
       .getHeadersModel(this.filteredOptions);
     this.listOptions = this.listModelService
       .getOptionsModel(this.filteredOptions, this.listHeaders, this.noGroupHeaders);
-    this.listModelService.setSelectedOptions(this.listHeaders, this.listOptions, this.value);
+    this.listModelService.setSelectedOptions(this.listHeaders, this.listOptions, this.selectedIdsMap);
+  }
+
+  private getSelectedIdsMap(): (string | number)[] {
+    return this.listModelService.getSelectedIdsMap(this.options);
+  }
+
+  private emitChange(): void {
+    const listChange: ListChange = this.listChangeService.getListChange(this.options, this.selectedIdsMap);
+    this.selectChange.emit(listChange);
   }
 }

--- a/projects/ui-framework/src/lib/form-elements/lists/multi-list/multi-list.module.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/multi-list/multi-list.module.ts
@@ -8,6 +8,7 @@ import { SearchModule } from '../../../navigation/search/search.module';
 import { FiltersModule } from '../../../services/filters/filters.module';
 import { ListOptionModule } from '../list-option/list-option.module';
 import { ListKeyboardService } from '../list-service/list-keyboard.service';
+import { ListChangeService } from '../list-change/list-change.service';
 
 @NgModule({
   declarations: [
@@ -26,6 +27,7 @@ import { ListKeyboardService } from '../list-service/list-keyboard.service';
   ],
   providers: [
     ListModelService,
+    ListChangeService,
     ListKeyboardService,
   ]
 })

--- a/projects/ui-framework/src/lib/form-elements/lists/multi-list/multi-list.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/multi-list/multi-list.stories.ts
@@ -16,7 +16,6 @@ const buttonStories = storiesOf(ComponentGroupType.FormElements, module).addDeco
 const template = `
 <b-multi-list style="width: 400px;"
               [options]="options"
-              [value]="value"
               [showSingleGroupHeader]="showSingleGroupHeader"
               (selectChange)="selectChange($event)">
 </b-multi-list>
@@ -24,7 +23,7 @@ const template = `
 
 const storyTemplate = `
 <b-story-book-layout title="Single select">
-  ${template}
+  ${ template }
 </b-story-book-layout>
 `;
 
@@ -38,23 +37,26 @@ const note = `
   Name | Type | Description | Default value
   --- | --- | --- | ---
   options | SelectGroupOption[] | model of selection group | none
-  value | (string or number) | selected id | none
-  selectChange | action | returns selected id | none
+  selectChange | action | returns ListChange | none
   showSingleGroupHeader | boolean | displays single group with group header | false
   maxHeight | number | component max height | 352 (8 rows)
 
   ~~~
-  ${template}
+  ${ template }
   ~~~
 `;
 
-const optionsMock: SelectGroupOption[] = Array.from(Array(5), (_, i) => {
+const groupNum = 6;
+const optionsNum = 3;
+
+const optionsMock: SelectGroupOption[] = Array.from(Array(groupNum), (_, i) => {
   return {
-    groupName: `Basic Info G${i} - header`,
-    options: Array.from(Array(4), (_, k) => {
+    groupName: `Basic Info G${ i } - header`,
+    options: Array.from(Array(optionsNum), (_, k) => {
       return {
-        value: `Basic Info G${i}_E${k} - option`,
-        id: i * 4 + k,
+        value: `Basic Info G${ i }_E${ k } - option`,
+        id: i * optionsNum + k,
+        selected: false,
         prefixComponent: {
           component: AvatarComponent,
           attributes: {
@@ -67,15 +69,17 @@ const optionsMock: SelectGroupOption[] = Array.from(Array(5), (_, i) => {
   };
 });
 
+optionsMock[0].options[1].selected = true;
+optionsMock[1].options[2].selected = true;
+
 buttonStories.add(
   'Multi list',
   () => ({
     template: storyTemplate,
     props: {
-      selectChange: action(),
+      selectChange: action('MultiListChange'),
       options: object<SelectGroupOption>('options', optionsMock),
-      value: array('value', [1, 3, 6, 8, 9, 10, 11]),
-      showSingleGroupHeader: boolean('showSingleGroupHeader', false)
+      showSingleGroupHeader: boolean('showSingleGroupHeader', true)
     },
     moduleMetadata: {
       imports: [

--- a/projects/ui-framework/src/lib/form-elements/lists/multi-select/multi-select.component.html
+++ b/projects/ui-framework/src/lib/form-elements/lists/multi-select/multi-select.component.html
@@ -5,7 +5,7 @@
 
   <b-input #triggerInput
            [disabled]="disabled"
-           [ngClass]="{'has-tooltip': showTriggerTooltip, 'has-clear-prefix': value.length > 0}"
+           [ngClass]="{'has-tooltip': showTriggerTooltip, 'has-clear-prefix': selectedValuesMap.length > 0}"
            [errorMessage]="errorMessage"
            [hintMessage]="hintMessage"
            [label]="label"
@@ -15,7 +15,7 @@
            [hideLabelOnFocus]="hideLabelOnFocus"
            [value]="triggerValue">
 
-    <div *ngIf="value.length > 0"
+    <div *ngIf="selectedValuesMap.length > 0"
          class="clear-selection"
          (click)="clearSelection()"
          input-prefix>
@@ -32,7 +32,7 @@
     <div input-suffix>
             <span *ngIf="showTriggerTooltip"
                   class="trigger-tooltip">
-          ({{value.length}})
+          ({{selectedValuesMap.length}})
         </span>
 
       <span class="select-chevron"></span>
@@ -47,9 +47,9 @@
   <div class="panel-position"
        [ngClass]="positionClassList">
 
-    <b-multi-list (selectChange)="onSelect($event)"
+    <b-multi-list #multiList
+                  (selectChange)="onSelect($event)"
                   [options]="options"
-                  [value]="value"
                   [maxHeight]="listElHeight*6"
                   [showSingleGroupHeader]="showSingleGroupHeader">
     </b-multi-list>

--- a/projects/ui-framework/src/lib/form-elements/lists/multi-select/multi-select.module.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/multi-select/multi-select.module.ts
@@ -8,9 +8,13 @@ import { InputModule } from '../../input/input.module';
 import { MultiListModule } from '../multi-list/multi-list.module';
 import { MatTooltipModule } from '@angular/material';
 import { IconsModule } from '../../../icons/icons.module';
+import { ListChangeService } from '../list-change/list-change.service';
+import { ListModelService } from '../list-service/list-model.service';
 
 @NgModule({
-  declarations: [MultiSelectComponent],
+  declarations: [
+    MultiSelectComponent,
+  ],
   imports: [
     CommonModule,
     PanelModule,
@@ -19,9 +23,14 @@ import { IconsModule } from '../../../icons/icons.module';
     MultiListModule,
     InputModule,
     MatTooltipModule,
-    IconsModule
+    IconsModule,
   ],
-  exports: [MultiSelectComponent],
-  providers: []
+  exports: [
+    MultiSelectComponent,
+  ],
+  providers: [
+    ListChangeService,
+    ListModelService,
+  ]
 })
 export class MultiSelectModule {}

--- a/projects/ui-framework/src/lib/form-elements/lists/multi-select/multi-select.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/multi-select/multi-select.stories.ts
@@ -17,8 +17,8 @@ const template = `
 <b-multi-select style="width: 400px;"
                 [label]="label"
                 [options]="options"
-                [value]="value"
                 (selectChange)="selectChange($event)"
+                (selectModified)="selectModified($event)"
                 [disabled]="disabled"
                 [required]="required"
                 [errorMessage]="errorMessage"
@@ -44,8 +44,8 @@ const note = `
   Name | Type | Description | Default value
   --- | --- | --- | ---
   options | SelectGroupOption[] | model of selection group | none
-  value | (string or number) | selected id | none
-  selectChange | action | returns selected id | none
+  selectChange | action | returns ListChange | none
+  selectModified | action | returns ListChange | none
   label | string | label text | none
   disabled | boolean | is field disabled | none
   required | boolean | is field required | none
@@ -59,13 +59,17 @@ const note = `
   ~~~
 `;
 
-const optionsMock: SelectGroupOption[] = Array.from(Array(3), (_, i) => {
+const groupNum = 3;
+const optionsNum = 4;
+
+const optionsMock: SelectGroupOption[] = Array.from(Array(groupNum), (_, i) => {
   return {
     groupName: `Basic Info G${i} - header`,
-    options: Array.from(Array(4), (_, k) => {
+    options: Array.from(Array(optionsNum), (_, k) => {
       return {
         value: `Basic Info G${i}_E${k} - option`,
-        id: i * 4 + k,
+        id: i * optionsNum + k,
+        selected: false,
         prefixComponent: {
           component: AvatarComponent,
           attributes: {
@@ -78,14 +82,17 @@ const optionsMock: SelectGroupOption[] = Array.from(Array(3), (_, i) => {
   };
 });
 
+optionsMock[0].options[1].selected = true;
+optionsMock[1].options[2].selected = true;
+
 buttonStories.add(
   'Multi select',
   () => ({
     template: storyTemplate,
     props: {
       options: object<SelectGroupOption>('options', optionsMock),
-      value: array('value', [2]),
-      selectChange: action(),
+      selectChange: action('MultiSelectChange'),
+      selectModified: action('MultiSelectModified'),
       label: text('label', 'label text'),
       disabled: boolean('disabled', false),
       required: boolean('required', false),

--- a/projects/ui-framework/src/lib/form-elements/lists/select-panel-element.abstract.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/select-panel-element.abstract.ts
@@ -95,7 +95,8 @@ export abstract class BaseSelectPanelElement extends BaseFormElement {
 
   updateTriggerTooltip(): void {
     setTimeout(() => {
-      this.showTriggerTooltip = this.triggerInput.bInput.nativeElement.scrollWidth > this.triggerInput.bInput.nativeElement.offsetWidth;
+      this.showTriggerTooltip = this.triggerInput.bInput.nativeElement.scrollWidth >
+        this.triggerInput.bInput.nativeElement.offsetWidth;
     });
   }
 }

--- a/projects/ui-framework/src/lib/form-elements/lists/single-list/single-list.component.html
+++ b/projects/ui-framework/src/lib/form-elements/lists/single-list/single-list.component.html
@@ -36,7 +36,7 @@
            [ngClass]="{
            'header-placeholder': option.isPlaceHolder,
            'option': !option.isPlaceHolder,
-           'selected': option.id===value,
+           'selected': option.selected,
            'focus': option.id===focusOption?.id
            }"
            class="option-select">

--- a/projects/ui-framework/src/lib/form-elements/lists/single-list/single-list.module.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/single-list/single-list.module.ts
@@ -7,6 +7,7 @@ import { SearchModule } from '../../../navigation/search/search.module';
 import { FiltersModule } from '../../../services/filters/filters.module';
 import { ListOptionModule } from '../list-option/list-option.module';
 import { ListKeyboardService } from '../list-service/list-keyboard.service';
+import { ListChangeService } from '../list-change/list-change.service';
 
 @NgModule({
   declarations: [
@@ -25,6 +26,7 @@ import { ListKeyboardService } from '../list-service/list-keyboard.service';
   providers: [
     ListModelService,
     ListKeyboardService,
+    ListChangeService,
   ],
 })
 export class SingleListModule {

--- a/projects/ui-framework/src/lib/form-elements/lists/single-list/single-list.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/single-list/single-list.stories.ts
@@ -16,7 +16,6 @@ const buttonStories = storiesOf(ComponentGroupType.FormElements, module).addDeco
 const template = `
 <b-single-list style="width: 400px;"
                [options]="options"
-               [value]="value"
                (selectChange)="selectChange($event)"
                [showSingleGroupHeader]="showSingleGroupHeader">
 </b-single-list>
@@ -38,8 +37,7 @@ const note = `
   Name | Type | Description | Default value
   --- | --- | --- | ---
   options | SelectGroupOption[] | model of selection group | none
-  value | (string or number) | selected id | none
-  selectChange | action | returns selected id | none
+  selectChange | action | returns ListChange | none
   showSingleGroupHeader | boolean | displays single group with group header | false
   maxHeight | number | component max height | 352 (8 rows)
 
@@ -48,13 +46,17 @@ const note = `
   ~~~
 `;
 
-const optionsMock: SelectGroupOption[] = Array.from(Array(6), (_, i) => {
+const groupNum = 3;
+const optionsNum = 4;
+
+const optionsMock: SelectGroupOption[] = Array.from(Array(groupNum), (_, i) => {
   return {
     groupName: `Basic Info G${i} - header`,
-    options: Array.from(Array(7), (_, k) => {
+    options: Array.from(Array(optionsNum), (_, k) => {
       return {
         value: `Basic Info G${i}_E${k} - option`,
-        id: i * 6 + k,
+        id: i * optionsNum + k,
+        selected: false,
         prefixComponent: {
           component: AvatarComponent,
           attributes: {
@@ -67,14 +69,15 @@ const optionsMock: SelectGroupOption[] = Array.from(Array(6), (_, i) => {
   };
 });
 
+optionsMock[0].options[1].selected = true;
+
 buttonStories.add(
   'Single list',
   () => ({
     template: storyTemplate,
     props: {
-      selectChange: action(),
+      selectChange: action('SingleListChange'),
       options: object<SelectGroupOption>('options', optionsMock),
-      value: number('value', 1),
       showSingleGroupHeader: boolean('showSingleGroupHeader', false)
     },
     moduleMetadata: {

--- a/projects/ui-framework/src/lib/form-elements/lists/single-select/single-select.component.html
+++ b/projects/ui-framework/src/lib/form-elements/lists/single-select/single-select.component.html
@@ -10,12 +10,12 @@
            [label]="label"
            [required]="required"
            [matTooltip]="showTriggerTooltip ? triggerValue : null"
-           [ngClass]="{'has-clear-prefix': value != null}"
+           [ngClass]="{'has-clear-prefix': selectedOptionId != null}"
            [value]="triggerValue"
            matTooltipPosition="above"
            [hideLabelOnFocus]="hideLabelOnFocus">
 
-    <div *ngIf="value != null"
+    <div *ngIf="selectedOptionId != null"
          class="clear-selection"
          (click)="clearSelection()"
          input-prefix>
@@ -42,7 +42,7 @@
        [ngClass]="positionClassList">
 
     <b-single-list (selectChange)="onSelect($event)"
-                   [options]="options"
+                   [options]="singleSelectOptions"
                    [maxHeight]="listElHeight*6"
                    [showSingleGroupHeader]="showSingleGroupHeader">
     </b-single-list>

--- a/projects/ui-framework/src/lib/form-elements/lists/single-select/single-select.module.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/single-select/single-select.module.ts
@@ -8,9 +8,13 @@ import { SingleListModule } from '../single-list/single-list.module';
 import { InputModule } from '../../input/input.module';
 import { MatTooltipModule } from '@angular/material';
 import { IconsModule } from '../../../icons/icons.module';
+import { ListChangeService } from '../list-change/list-change.service';
+import { ListModelService } from '../list-service/list-model.service';
 
 @NgModule({
-  declarations: [SingleSelectComponent],
+  declarations: [
+    SingleSelectComponent,
+  ],
   imports: [
     CommonModule,
     PanelModule,
@@ -21,7 +25,12 @@ import { IconsModule } from '../../../icons/icons.module';
     MatTooltipModule,
     IconsModule
   ],
-  exports: [SingleSelectComponent],
-  providers: []
+  exports: [
+    SingleSelectComponent,
+  ],
+  providers: [
+    ListChangeService,
+    ListModelService,
+  ]
 })
 export class SingleSelectModule {}

--- a/projects/ui-framework/src/lib/form-elements/lists/single-select/single-select.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/single-select/single-select.stories.ts
@@ -15,7 +15,6 @@ const template = `
 <b-single-select style="width: 400px;"
                  [label]="label"
                  [options]="options"
-                 [value]="value"
                  (selectChange)="selectChange($event)"
                  [disabled]="disabled"
                  [required]="required"
@@ -43,7 +42,7 @@ const note = `
   --- | --- | --- | ---
   options | SelectGroupOption[] | model of selection group | none
   value | (string or number) | selected id | none
-  selectChange | action | returns selected id | none
+  selectChange | action | returns ListChange | none
   label | string | label text | none
   disabled | boolean | is field disabled | none
   required | boolean | is field required | none
@@ -57,20 +56,26 @@ const note = `
   ~~~
 `;
 
-const optionsMock = Array.from(Array(2), (_, i) => {
+const groupNum = 6;
+const optionsNum = 3;
+
+const optionsMock: SelectGroupOption[] = Array.from(Array(groupNum), (_, i) => {
   return {
     groupName: `Personal G${i}`,
-    options: Array.from(Array(3), (_, k) => {
+    options: Array.from(Array(optionsNum), (_, k) => {
       return {
         value:
           k % 2 === 0
             ? `Personal G${i}_E${k} and some other very long text and some more words to have ellipsis and tooltip`
             : `Personal G${i}_E${k}`,
-        id: i * 4 + k
+        id: i * optionsNum + k,
+        selected: false,
       };
     })
   };
 });
+
+optionsMock[0].options[1].selected = true;
 
 buttonStories.add(
   'Single select',
@@ -78,8 +83,7 @@ buttonStories.add(
     template: storyTemplate,
     props: {
       options: object<SelectGroupOption>('options', optionsMock),
-      value: number('value', null),
-      selectChange: action(),
+      selectChange: action('SingleSelectChange'),
       label: text('label', 'label text'),
       disabled: boolean('disabled', false),
       required: boolean('required', false),

--- a/projects/ui-framework/src/lib/form-elements/split-input-single-select/split-input-single-select.component.html
+++ b/projects/ui-framework/src/lib/form-elements/split-input-single-select/split-input-single-select.component.html
@@ -12,8 +12,7 @@
 
   <b-single-select (selectChange)="onSelectChange($event)"
                    [disabled]="disabled"
-                   [options]="selectOptions"
-                   [showSingleGroupHeader]="false"
-                   [value]="value?.selectValue">
+                   [options]="options"
+                   [showSingleGroupHeader]="false">
   </b-single-select>
 </div>

--- a/projects/ui-framework/src/lib/form-elements/split-input-single-select/split-input-single-select.component.spec.ts
+++ b/projects/ui-framework/src/lib/form-elements/split-input-single-select/split-input-single-select.component.spec.ts
@@ -9,27 +9,33 @@ import { InputComponent } from '../input/input.component';
 import { SelectGroupOption } from '../lists/list.interface';
 import { InputSingleSelectValue } from './split-input-single-select.interface';
 import { By } from '@angular/platform-browser';
+import { cloneDeep } from 'lodash';
+import { ListChange } from '../lists/list-change/list-change';
 
 describe('SplitInputSingleSelectComponent', () => {
   let component: SplitInputSingleSelectComponent;
   let fixture: ComponentFixture<SplitInputSingleSelectComponent>;
-  const optionsMock: SelectGroupOption[] = [
-    {
-      groupName: 'currencies',
-      options: [
-        { value: 'USD', id: 'USD' },
-        { value: 'GBP', id: 'GBP' },
-        { value: 'ILS', id: 'ILS' }
-      ]
-    }
-  ];
-
-  const valueMock: InputSingleSelectValue = {
-    inputValue: 200,
-    selectValue: 'USD'
-  };
+  let optionsMock: SelectGroupOption[];
+  let valueMock: InputSingleSelectValue;
 
   beforeEach(async(() => {
+
+    valueMock = {
+      inputValue: 200,
+      selectValue: 'USD'
+    };
+
+    optionsMock = [
+      {
+        groupName: 'currencies',
+        options: [
+          { value: 'USD', id: 'USD', selected: false },
+          { value: 'GBP', id: 'GBP', selected: false },
+          { value: 'ILS', id: 'ILS', selected: false },
+        ]
+      }
+    ];
+
     TestBed.configureTestingModule({
       declarations: [
         SplitInputSingleSelectComponent,
@@ -67,19 +73,37 @@ describe('SplitInputSingleSelectComponent', () => {
       const inputEl = fixture.debugElement.query(By.css('b-input'));
       expect(inputEl.context.value).toEqual(valueMock.inputValue);
     });
-    it('should set selectValue as value on the selectEl', () => {
+    it('should enrich selectOptions with select=true from value', () => {
+      const expectedOptions = cloneDeep(optionsMock);
+      expectedOptions[0].options[0].selected = true;
       component.value = valueMock;
-      component.ngOnChanges({});
-      fixture.detectChanges();
-      const selectEl = fixture.debugElement.query(By.css('b-single-select'));
-      expect(selectEl.context.value).toEqual(valueMock.selectValue);
+      component.ngOnChanges({
+        selectOptions:
+          {
+            previousValue: undefined,
+            currentValue: optionsMock,
+            firstChange: false,
+            isFirstChange: () => false,
+          },
+      });
+      expect(component.options).toEqual(expectedOptions);
     });
-    it('should set options on select element', () => {
-      component.selectOptions = optionsMock;
-      component.ngOnChanges({});
+    it('should set selectedOptions as options on the selectEl', () => {
+      const expectedOptions = cloneDeep(optionsMock);
+      expectedOptions[0].options[0].selected = true;
+      component.value = valueMock;
+      component.ngOnChanges({
+        selectOptions:
+          {
+            previousValue: undefined,
+            currentValue: optionsMock,
+            firstChange: false,
+            isFirstChange: () => false,
+          },
+      });
       fixture.detectChanges();
       const selectEl = fixture.debugElement.query(By.css('b-single-select'));
-      expect(selectEl.context.options).toEqual(optionsMock);
+      expect(selectEl.context.options).toEqual(expectedOptions);
     });
   });
 
@@ -121,12 +145,15 @@ describe('SplitInputSingleSelectComponent', () => {
       fixture.detectChanges();
     });
     it('should update value and emit event with updated value', () => {
+      const listElOptions = cloneDeep(optionsMock);
+      listElOptions[0].options[1].selected = true;
       const selectEl = fixture.debugElement.query(By.css('b-single-select'));
-      selectEl.context.selectChange.emit('GBP');
+      const listChange = new ListChange(listElOptions);
+      selectEl.context.selectChange.emit(listChange);
       fixture.detectChanges();
       expect(component.elementChange.emit).toHaveBeenCalledWith({
         inputValue: 200,
-        selectValue: 'GBP'
+        selectValue: 'GBP',
       });
     });
   });

--- a/projects/ui-framework/src/lib/form-elements/split-input-single-select/split-input-single-select.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/split-input-single-select/split-input-single-select.stories.ts
@@ -47,7 +47,7 @@ const note = `
   required | boolean | is field required
   hintMessage | text | hint text
   errorMessage | text | error text
-  elementChange | Action | element change emitter
+  elementChange | return { value, selectedId } | element change emitter
 
   ~~~
   ${template}
@@ -114,14 +114,15 @@ const optionsMock: SelectGroupOption[] = Array.from(Array(1), (_, i) => {
     groupName: 'all currencies',
     options: map(currencies, (currency) => ({
       value: currency.value,
-      id: currency.value
+      id: currency.value,
+      selected: null,
     }))
   };
 });
 
 const value: InputSingleSelectValue = {
   inputValue: 100,
-  selectValue: 'GBP'
+  selectValue: 'AED'
 };
 
 textareaStories.add(
@@ -138,7 +139,7 @@ textareaStories.add(
         required: boolean('required', false),
         hintMessage: text('hintMessage', 'This field should contain something'),
         errorMessage: text('errorMessage', ''),
-        elementChange: action()
+        elementChange: action('SplitInputSingleSelectChange'),
       },
       moduleMetadata: {
         imports: [BrowserAnimationsModule, StoryBookLayoutModule, SplitInputSingleSelectModule]

--- a/projects/ui-framework/src/lib/navigation/auto-complete/auto-complete.component.spec.ts
+++ b/projects/ui-framework/src/lib/navigation/auto-complete/auto-complete.component.spec.ts
@@ -79,7 +79,6 @@ describe('AutoCompleteComponent', () => {
   describe('searchChange', () => {
     it('should open panel if search has value', () => {
       let panel = overlayContainerElement.querySelector('b-auto-complete-panel');
-      console.log('panel', panel);
       expect(panel).toBeFalsy();
       const searchEl = fixture.debugElement.query(By.css('b-search'));
       searchEl.componentInstance.searchChange.emit('e1');
@@ -151,7 +150,6 @@ describe('AutoCompleteComponent', () => {
 
       component.ngOnDestroy();
 
-      console.log(component['positionChangeSubscriber']);
       expect(component['positionChangeSubscriber'].closed).toBe(true);
       expect(component['backdropClickSubscriber'].closed).toBe(true);
       expect(component['panelOpen']).toBe(false);

--- a/projects/ui-framework/src/lib/navigation/quick-filter/quick-filter-bar.component.spec.ts
+++ b/projects/ui-framework/src/lib/navigation/quick-filter/quick-filter-bar.component.spec.ts
@@ -6,49 +6,62 @@ import { QuickFilterSelectType } from './quick-filter.enum';
 import { By } from '@angular/platform-browser';
 import { QuickFilterComponent } from './quick-filter.component';
 import { MockComponent } from 'ng-mocks';
-import { QuickFilterChangeEvent } from './quick-filter.interface';
+import { QuickFilterChangeEvent, QuickFilterConfig } from './quick-filter.interface';
+import { ListModelService } from '../../form-elements/lists/list-service/list-model.service';
+import { ListChangeService } from '../../form-elements/lists/list-change/list-change.service';
+import { ListChange } from '../../form-elements/lists/list-change/list-change';
 
 describe('QuickFilterBarComponent', () => {
   let component: QuickFilterBarComponent;
   let fixture: ComponentFixture<QuickFilterBarComponent>;
 
-  const optionsMock: SelectGroupOption[] = Array.from(Array(3), (_, i) => {
-    return {
-      groupName: `Basic Info G${ i } - header`,
-      options: Array.from(Array(4), (_, k) => {
-        return {
-          value: `Basic Info G${ i }_E${ k } - option`,
-          id: i * 4 + k,
-        };
-      })
-    };
-  });
-  const quickFiltersMock = [
-    {
-      selectType: QuickFilterSelectType.multiSelect,
-      label: 'department',
-      options: [optionsMock[0]],
-      value: [1, 2],
-    },
-    {
-      selectType: QuickFilterSelectType.multiSelect,
-      label: 'site',
-      options: optionsMock,
-      value: [],
-    },
-    {
-      selectType: QuickFilterSelectType.singleSelect,
-      label: 'employment',
-      options: [optionsMock[0]],
-      value: null,
-    },
-  ];
+  let optionsMock: SelectGroupOption[];
+  let quickFiltersMock: QuickFilterConfig[];
 
   beforeEach(async(() => {
+
+    optionsMock = Array.from(Array(3), (_, i) => {
+      return {
+        groupName: `Basic Info G${ i } - header`,
+        options: Array.from(Array(4), (_, k) => {
+          return {
+            value: `Basic Info G${ i }_E${ k } - option`,
+            id: i * 4 + k,
+            selected: false,
+          };
+        })
+      };
+    });
+
+    quickFiltersMock = [
+      {
+        selectType: QuickFilterSelectType.multiSelect,
+        label: 'department',
+        key: 'department',
+        options: [optionsMock[0]],
+      },
+      {
+        selectType: QuickFilterSelectType.multiSelect,
+        label: 'site',
+        key: 'site',
+        options: optionsMock,
+      },
+      {
+        selectType: QuickFilterSelectType.singleSelect,
+        label: 'employment',
+        key: 'employment',
+        options: [optionsMock[0]],
+      },
+    ];
+
     TestBed.configureTestingModule({
       declarations: [
         QuickFilterBarComponent,
         MockComponent(QuickFilterComponent),
+      ],
+      providers: [
+        ListModelService,
+        ListChangeService,
       ],
       imports: [
         NoopAnimationsModule,
@@ -81,9 +94,18 @@ describe('QuickFilterBarComponent', () => {
       });
       fixture.detectChanges();
       expect(component.quickFiltersChanges).toEqual({
-        department: [1, 2],
-        site: [],
-        employment: null,
+        department: {
+          key: 'department',
+          listChange: new ListChange([optionsMock[0]]),
+        },
+        site: {
+          key: 'site',
+          listChange: new ListChange(optionsMock),
+        },
+        employment: {
+          key: 'employment',
+          listChange: new ListChange([optionsMock[0]]),
+        },
       });
     });
   });
@@ -92,35 +114,56 @@ describe('QuickFilterBarComponent', () => {
     beforeEach(() => {
       component.ngOnChanges({
         quickFilters: {
-          previousValue: undefined, currentValue: quickFiltersMock, firstChange: true, isFirstChange: () => true,
+          previousValue: undefined,
+          currentValue: quickFiltersMock,
+          firstChange: true,
+          isFirstChange: () => true,
         },
       });
       fixture.detectChanges();
     });
     it('should update quickFiltersChanges model with the changed filter value', () => {
       const changedFilter: QuickFilterChangeEvent = {
-        label: 'site',
-        value: [1],
+        key: 'site',
+        listChange: new ListChange(optionsMock),
       };
       const quickFilterSiteEl = fixture.debugElement.queryAll(By.css('b-quick-filter'))[1];
       quickFilterSiteEl.componentInstance.filterChange.emit(changedFilter);
       expect(component.quickFiltersChanges).toEqual({
-        department: [1, 2],
-        site: [1],
-        employment: null,
+        department: {
+          key: 'department',
+          listChange: new ListChange([optionsMock[0]]),
+        },
+        site: {
+          key: 'site',
+          listChange: new ListChange(optionsMock),
+        },
+        employment: {
+          key: 'employment',
+          listChange: new ListChange([optionsMock[0]]),
+        },
       });
     });
     it('should invoke onFilterChange.emit with the quickFiltersChanges model', () => {
       const changedFilter: QuickFilterChangeEvent = {
-        label: 'site',
-        value: [1],
+        key: 'department',
+        listChange: new ListChange([optionsMock[0]]),
       };
       const quickFilterSiteEl = fixture.debugElement.queryAll(By.css('b-quick-filter'))[1];
       quickFilterSiteEl.componentInstance.filterChange.emit(changedFilter);
       expect(component.filtersChange.emit).toHaveBeenCalledWith({
-        department: [1, 2],
-        site: [1],
-        employment: null,
+        department: {
+          key: 'department',
+          listChange: new ListChange([optionsMock[0]]),
+        },
+        site: {
+          key: 'site',
+          listChange: new ListChange(optionsMock),
+        },
+        employment: {
+          key: 'employment',
+          listChange: new ListChange([optionsMock[0]]),
+        },
       });
     });
   });

--- a/projects/ui-framework/src/lib/navigation/quick-filter/quick-filter.component.html
+++ b/projects/ui-framework/src/lib/navigation/quick-filter/quick-filter.component.html
@@ -12,7 +12,7 @@
   <b-multi-select [ngClass]="{'has-value': hasValue}"
                   [options]="quickFilterConfig.options"
                   [value]="quickFilterConfig.value"
-                  (selectChange)="multiSelectChange($event)"
+                  (selectChange)="selectChange($event)"
                   (selectModified)="multiSelectModified($event)"
                   [disabled]="false"
                   [required]="false"
@@ -24,8 +24,7 @@
 <ng-template #singleSelect let-quickFilterConfig>
   <b-single-select [ngClass]="{'has-value': hasValue}"
                    [options]="quickFilterConfig.options"
-                   [value]="quickFilterConfig.value"
-                   (selectChange)="singleSelectChange($event)"
+                   (selectChange)="selectChange($event)"
                    [disabled]="false"
                    [required]="false"
                    [showSingleGroupHeader]="showSingleGroupHeader"

--- a/projects/ui-framework/src/lib/navigation/quick-filter/quick-filter.component.spec.ts
+++ b/projects/ui-framework/src/lib/navigation/quick-filter/quick-filter.component.spec.ts
@@ -7,29 +7,38 @@ import { MockComponent } from 'ng-mocks';
 import { QuickFilterComponent } from './quick-filter.component';
 import { MultiSelectComponent } from '../../form-elements/lists/multi-select/multi-select.component';
 import { SingleSelectComponent } from '../../form-elements/lists/single-select/single-select.component';
+import { ListModelService } from '../../form-elements/lists/list-service/list-model.service';
+import { ListChange } from '../../form-elements/lists/list-change/list-change';
+import { QuickFilterConfig } from './quick-filter.interface';
 
 describe('QuickFilterComponent', () => {
   let component: QuickFilterComponent;
   let fixture: ComponentFixture<QuickFilterComponent>;
-
-  const optionsMock: SelectGroupOption[] = Array.from(Array(3), (_, i) => {
-    return {
-      groupName: `Basic Info G${ i } - header`,
-      options: Array.from(Array(4), (_, k) => {
-        return {
-          value: `Basic Info G${ i }_E${ k } - option`,
-          id: i * 4 + k,
-        };
-      })
-    };
-  });
+  let optionsMock: SelectGroupOption[];
 
   beforeEach(async(() => {
+
+    optionsMock = Array.from(Array(3), (_, i) => {
+      return {
+        groupName: `Basic Info G${ i } - header`,
+        options: Array.from(Array(4), (_, k) => {
+          return {
+            selected: false,
+            value: `Basic Info G${ i }_E${ k } - option`,
+            id: i * 4 + k,
+          };
+        })
+      };
+    });
+
     TestBed.configureTestingModule({
       declarations: [
         QuickFilterComponent,
         MockComponent(MultiSelectComponent),
         MockComponent(SingleSelectComponent),
+      ],
+      providers: [
+        ListModelService,
       ],
       imports: [
         NoopAnimationsModule,
@@ -45,11 +54,11 @@ describe('QuickFilterComponent', () => {
 
   describe('OnChanges', () => {
     it('should render multi select element', () => {
-      const quickFilterConfig = {
+      const quickFilterConfig: QuickFilterConfig = {
         selectType: QuickFilterSelectType.multiSelect,
         label: 'department',
+        key: 'department',
         options: [optionsMock[0]],
-        value: [1, 2],
       };
       component.ngOnChanges({
         quickFilterConfig: {
@@ -63,11 +72,11 @@ describe('QuickFilterComponent', () => {
       expect(singleSelectEl.length).toEqual(0);
     });
     it('should render single select element', () => {
-      const quickFilterConfig = {
+      const quickFilterConfig: QuickFilterConfig = {
         selectType: QuickFilterSelectType.singleSelect,
         label: 'department',
+        key: 'department',
         options: [optionsMock[0]],
-        value: 1,
       };
       component.ngOnChanges({
         quickFilterConfig: {
@@ -80,46 +89,36 @@ describe('QuickFilterComponent', () => {
       expect(multiSelectEl.length).toEqual(0);
       expect(singleSelectEl.length).toEqual(1);
     });
-    it('should set hasValue to true if value is passed in config', () => {
-      const quickFilterConfig = {
+    it('should set hasValue to true if some options are selected', () => {
+      optionsMock[0].options[0].selected = true;
+      const quickFilterConfig: QuickFilterConfig = {
         selectType: QuickFilterSelectType.singleSelect,
         label: 'department',
+        key: 'department',
         options: [optionsMock[0]],
-        value: 1,
       };
       component.ngOnChanges({
         quickFilterConfig: {
-          previousValue: undefined, currentValue: quickFilterConfig, firstChange: true, isFirstChange: () => true,
+          previousValue: undefined,
+          currentValue: quickFilterConfig,
+          firstChange: true, isFirstChange: () => true,
         }
       });
       fixture.detectChanges();
       expect(component.hasValue).toBe(true);
     });
-    it('should set hasValue to false if value in config is null', () => {
-      const quickFilterConfig = {
+    it('should set hasValue to false if no options are selected', () => {
+      const quickFilterConfig: QuickFilterConfig = {
         selectType: QuickFilterSelectType.singleSelect,
         label: 'department',
+        key: 'department',
         options: [optionsMock[0]],
-        value: null,
       };
       component.ngOnChanges({
         quickFilterConfig: {
-          previousValue: undefined, currentValue: quickFilterConfig, firstChange: true, isFirstChange: () => true,
-        }
-      });
-      fixture.detectChanges();
-      expect(component.hasValue).toBe(false);
-    });
-    it('should set hasValue to false if value in config is empty', () => {
-      const quickFilterConfig = {
-        selectType: QuickFilterSelectType.multiSelect,
-        label: 'department',
-        options: [optionsMock[0]],
-        value: [],
-      };
-      component.ngOnChanges({
-        quickFilterConfig: {
-          previousValue: undefined, currentValue: quickFilterConfig, firstChange: true, isFirstChange: () => true,
+          previousValue: undefined,
+          currentValue: quickFilterConfig,
+          firstChange: true, isFirstChange: () => true,
         }
       });
       fixture.detectChanges();
@@ -128,86 +127,110 @@ describe('QuickFilterComponent', () => {
   });
 
   describe('multiSelectModified', () => {
-    it('should update hasValue to true', () => {
-      const quickFilterConfig = {
+    beforeEach(() => {
+      const quickFilterConfig: QuickFilterConfig = {
         selectType: QuickFilterSelectType.multiSelect,
         label: 'department',
+        key: 'department',
         options: [optionsMock[0]],
-        value: [],
       };
       component.ngOnChanges({
         quickFilterConfig: {
-          previousValue: undefined, currentValue: quickFilterConfig, firstChange: true, isFirstChange: () => true,
+          previousValue: undefined,
+          currentValue: quickFilterConfig,
+          firstChange: true, isFirstChange: () => true,
         }
       });
       fixture.detectChanges();
+    });
+    it('should update hasValue to true is some options are selected', () => {
+      optionsMock[0].options[0].selected = true;
+      const listChange: ListChange = new ListChange([optionsMock[0]]);
       const multiSelectEl = fixture.debugElement.query(By.css('b-multi-select'));
-      multiSelectEl.componentInstance.selectModified.emit([1]);
+      multiSelectEl.componentInstance.selectModified.emit(listChange);
       fixture.detectChanges();
       expect(component.hasValue).toBe(true);
+    });
+    it('should update hasValue to false to false if no options are selected', () => {
+      const listChange: ListChange = new ListChange([optionsMock[0]]);
+      const multiSelectEl = fixture.debugElement.query(By.css('b-multi-select'));
+      multiSelectEl.componentInstance.selectModified.emit(listChange);
+      fixture.detectChanges();
+      expect(component.hasValue).toBe(false);
     });
   });
 
-  describe('multiSelectChange', () => {
-    beforeEach(() => {
-      const quickFilterConfig = {
-        selectType: QuickFilterSelectType.multiSelect,
+  describe('selectChange', () => {
+    const createQuickFilter = (quickFilterSelectType: QuickFilterSelectType) => {
+      const quickFilterConfig: QuickFilterConfig = {
+        selectType: quickFilterSelectType,
         label: 'department',
+        key: 'department',
         options: [optionsMock[0]],
-        value: [],
       };
       component.ngOnChanges({
         quickFilterConfig: {
-          previousValue: undefined, currentValue: quickFilterConfig, firstChange: true, isFirstChange: () => true,
+          previousValue: undefined,
+          currentValue: quickFilterConfig,
+          firstChange: true, isFirstChange: () => true,
         }
       });
       fixture.detectChanges();
-    });
-    it('should update hasValue to true', () => {
+    };
+    it('should set hasValue to true is some options are selected - multiSelect', () => {
+      createQuickFilter(QuickFilterSelectType.multiSelect);
+      optionsMock[0].options[0].selected = true;
+      const listChange: ListChange = new ListChange([optionsMock[0]]);
       const multiSelectEl = fixture.debugElement.query(By.css('b-multi-select'));
-      multiSelectEl.componentInstance.selectChange.emit([1]);
+      multiSelectEl.componentInstance.selectChange.emit(listChange);
       fixture.detectChanges();
       expect(component.hasValue).toBe(true);
     });
-    it('should invoke filterChange.emit with label and value', () => {
-      const multiSelectEl = fixture.debugElement.query(By.css('b-multi-select'));
-      multiSelectEl.componentInstance.selectChange.emit([1]);
-      fixture.detectChanges();
-      expect(component.filterChange.emit).toHaveBeenCalledWith({
-        label: 'department',
-        value: [1],
-      });
-    });
-  });
-
-  describe('singleSelectChange', () => {
-    beforeEach(() => {
-      const quickFilterConfig = {
-        selectType: QuickFilterSelectType.singleSelect,
-        label: 'department',
-        options: [optionsMock[0]],
-        value: null,
-      };
-      component.ngOnChanges({
-        quickFilterConfig: {
-          previousValue: undefined, currentValue: quickFilterConfig, firstChange: true, isFirstChange: () => true,
-        }
-      });
-      fixture.detectChanges();
-    });
-    it('should update hasValue to true', () => {
-      const multiSelectEl = fixture.debugElement.query(By.css('b-single-select'));
-      multiSelectEl.componentInstance.selectChange.emit(1);
+    it('should set hasValue to true is some options are selected - singleSelect', () => {
+      createQuickFilter(QuickFilterSelectType.singleSelect);
+      optionsMock[0].options[0].selected = true;
+      const listChange: ListChange = new ListChange([optionsMock[0]]);
+      const singleListEl = fixture.debugElement.query(By.css('b-single-select'));
+      singleListEl.componentInstance.selectChange.emit(listChange);
       fixture.detectChanges();
       expect(component.hasValue).toBe(true);
     });
-    it('should invoke filterChange.emit with label and value', () => {
-      const multiSelectEl = fixture.debugElement.query(By.css('b-single-select'));
-      multiSelectEl.componentInstance.selectChange.emit(1);
+    it('should set hasValue to false is some options are selected - multiSelect', () => {
+      createQuickFilter(QuickFilterSelectType.multiSelect);
+      const listChange: ListChange = new ListChange([optionsMock[0]]);
+      const multiSelectEl = fixture.debugElement.query(By.css('b-multi-select'));
+      multiSelectEl.componentInstance.selectChange.emit(listChange);
+      fixture.detectChanges();
+      expect(component.hasValue).toBe(false);
+    });
+    it('should set hasValue to false is some options are selected - singleSelect', () => {
+      createQuickFilter(QuickFilterSelectType.singleSelect);
+      const listChange: ListChange = new ListChange([optionsMock[0]]);
+      const singleListEl = fixture.debugElement.query(By.css('b-single-select'));
+      singleListEl.componentInstance.selectChange.emit(listChange);
+      fixture.detectChanges();
+      expect(component.hasValue).toBe(false);
+    });
+    it('should emit QuickFilterChangeEvent - multiSelect', () => {
+      createQuickFilter(QuickFilterSelectType.multiSelect);
+      const listChange: ListChange = new ListChange([optionsMock[0]]);
+      const multiSelectEl = fixture.debugElement.query(By.css('b-multi-select'));
+      multiSelectEl.componentInstance.selectChange.emit(listChange);
       fixture.detectChanges();
       expect(component.filterChange.emit).toHaveBeenCalledWith({
-        label: 'department',
-        value: 1,
+        key: 'department',
+        listChange,
+      });
+    });
+    it('should emit QuickFilterChangeEvent - singleSelect', () => {
+      createQuickFilter(QuickFilterSelectType.singleSelect);
+      const listChange: ListChange = new ListChange([optionsMock[0]]);
+      const singleListEl = fixture.debugElement.query(By.css('b-single-select'));
+      singleListEl.componentInstance.selectChange.emit(listChange);
+      fixture.detectChanges();
+      expect(component.filterChange.emit).toHaveBeenCalledWith({
+        key: 'department',
+        listChange,
       });
     });
   });

--- a/projects/ui-framework/src/lib/navigation/quick-filter/quick-filter.interface.ts
+++ b/projects/ui-framework/src/lib/navigation/quick-filter/quick-filter.interface.ts
@@ -1,18 +1,19 @@
 import { SelectGroupOption } from '../../form-elements/lists/list.interface';
 import { QuickFilterSelectType } from './quick-filter.enum';
+import { ListChange } from '../../form-elements/lists/list-change/list-change';
 
 export interface QuickFilterConfig {
   selectType: QuickFilterSelectType;
   label: string;
+  key: string;
   options: SelectGroupOption[];
-  value: (string | number) | (string | number)[];
 }
 
 export interface QuickFilterChangeEvent {
-  label: string;
-  value: (string | number) | (string | number)[];
+  key: string;
+  listChange: ListChange;
 }
 
 export interface QuickFilterBarChangeEvent {
-  [key: string]: (string | number) | (string | number)[];
+  [key: string]: QuickFilterChangeEvent;
 }

--- a/projects/ui-framework/src/lib/navigation/quick-filter/quick-filter.module.ts
+++ b/projects/ui-framework/src/lib/navigation/quick-filter/quick-filter.module.ts
@@ -5,6 +5,8 @@ import { QuickFilterComponent } from './quick-filter.component';
 import { MultiSelectModule } from '../../form-elements/lists/multi-select/multi-select.module';
 import { PanelPositionService } from '../../overlay/panel/panel-position.service';
 import { SingleSelectModule } from '../../form-elements/lists/single-select/single-select.module';
+import { ListModelService } from '../../form-elements/lists/list-service/list-model.service';
+import { ListChangeService } from '../../form-elements/lists/list-change/list-change.service';
 
 @NgModule({
   declarations: [
@@ -18,6 +20,8 @@ import { SingleSelectModule } from '../../form-elements/lists/single-select/sing
   ],
   providers: [
     PanelPositionService,
+    ListModelService,
+    ListChangeService,
   ],
   exports: [
     QuickFilterComponent,

--- a/projects/ui-framework/src/lib/navigation/quick-filter/quick-filter.stories.ts
+++ b/projects/ui-framework/src/lib/navigation/quick-filter/quick-filter.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/angular';
 import { text, select, boolean, withKnobs, number, object } from '@storybook/addon-knobs/angular';
 import { action } from '@storybook/addon-actions';
-import { values } from 'lodash';
+import { values, cloneDeep } from 'lodash';
 import { ComponentGroupType } from '../../consts';
 import { StoryBookLayoutModule } from '../../story-book-layout/story-book-layout.module';
 import { QuickFilterModule } from './quick-filter.module';
@@ -19,13 +19,13 @@ const template = `
                     [quickFilters]="quickFilters"
                     (filtersChange)="filtersChange($event)">
   <div bar-prefix>total: 85</div>
-  <b-button bar-suffix size="${ButtonSize.small}">more</b-button>
+  <b-button bar-suffix size="${ ButtonSize.small }">more</b-button>
 </b-quick-filter-bar>
 `;
 
 const storyTemplate = `
 <b-story-book-layout title="Textarea">
-  ${template}
+  ${ template }
 </b-story-book-layout>
 `;
 
@@ -41,17 +41,21 @@ const note = `
   filtersChange | QuickFilterBarChangeEvent | Output of quick filter bar change | none
 
   ~~~
-  ${template}
+  ${ template }
   ~~~
 `;
 
-const optionsMock: SelectGroupOption[] = Array.from(Array(3), (_, i) => {
+const groupNun = 3;
+const optionsNum = 4;
+
+const optionsMock: SelectGroupOption[] = Array.from(Array(groupNun), (_, i) => {
   return {
-    groupName: `Basic Info G${i} - header`,
-    options: Array.from(Array(4), (_, k) => {
+    groupName: `Basic Info G${ i } - header`,
+    options: Array.from(Array(optionsNum), (_, k) => {
       return {
-        value: `Basic Info G${i}_E${k} - option`,
-        id: i * 4 + k
+        selected: false,
+        value: `Basic Info G${ i }_E${ k } - option`,
+        id: i * optionsNum + k
       };
     })
   };
@@ -61,22 +65,26 @@ const quickFilters: QuickFilterConfig[] = [
   {
     selectType: QuickFilterSelectType.multiSelect,
     label: 'department',
-    options: [optionsMock[0]],
-    value: [1, 2]
+    key: 'department',
+    options: [cloneDeep(optionsMock[0]), cloneDeep(optionsMock[1])],
   },
   {
     selectType: QuickFilterSelectType.multiSelect,
     label: 'site',
-    options: optionsMock,
-    value: []
+    key: 'site',
+    options: cloneDeep(optionsMock),
   },
   {
     selectType: QuickFilterSelectType.singleSelect,
     label: 'employment',
-    options: [optionsMock[0]],
-    value: null
+    key: 'employment',
+    options: [cloneDeep(optionsMock[0])],
   }
 ];
+
+quickFilters[0].options[0].options[1].selected = true;
+quickFilters[0].options[1].options[1].selected = true;
+quickFilters[2].options[0].options[3].selected = true;
 
 textareaStories.add(
   'Quick filters',
@@ -85,7 +93,7 @@ textareaStories.add(
       template: storyTemplate,
       props: {
         quickFilters: object('quickFilters', quickFilters),
-        filtersChange: action()
+        filtersChange: action('QuickFilterBarChange'),
       },
       moduleMetadata: {
         imports: [BrowserAnimationsModule, StoryBookLayoutModule, QuickFilterModule, ButtonsModule]

--- a/projects/ui-framework/src/lib/overlay/dialog/dialog-example.module.ts
+++ b/projects/ui-framework/src/lib/overlay/dialog/dialog-example.module.ts
@@ -132,7 +132,10 @@ export class ExampleDialog1Component implements OnInit {
     this.selectOptions = [
       {
         groupName: 'Article interest options',
-        options: [{ id: 1, value: 'yes' }, { id: 2, value: 'no' }]
+        options: [
+          { id: 1, value: 'yes', selected: false, },
+          { id: 2, value: 'no', selected: false, },
+        ]
       }
     ];
   }


### PR DESCRIPTION
- added optional 'key' attribute to option group
- selected attribute is mandatory for list option
- no value input in lists, selected come from options model
- Lists (single list, multi list, single select, multi select) emit ListChange
- QuickFilterBar emits
```
[key]: {
  key: string,
  listChange: ListChange
}
```

cc: @danazelniker 