### PR TITLE
Pavel/rich text editor

### DIFF
--- a/projects/app-test/src/app/app.component.html
+++ b/projects/app-test/src/app/app.component.html
@@ -3,16 +3,12 @@
   <b-display-1>Hello</b-display-1>
 
 
-<form>
+  <form>
 
-  <b-rich-text-editor
-                      [formControl]="rteControl">
-  </b-rich-text-editor>
+    <b-rich-text-editor [formControl]="rteControl">
+    </b-rich-text-editor>
+    <br>
+    <input type="text"
+           [formControl]="inputControl">
 
-  <b-checkbox [formControl]="checkControl">
-  </b-checkbox>
-
-  <input type="text"
-         [formControl]="inputControl">
-
-</form>
+  </form>

--- a/projects/app-test/src/app/app.component.ts
+++ b/projects/app-test/src/app/app.component.ts
@@ -20,10 +20,16 @@ export class AppComponent implements OnInit {
 
     this.inputControl.valueChanges.subscribe(value => {
       console.log('INP valueChanges', value);
-      this.rteControl.setValue(value, { emitEvent: false });
+      this.rteControl.setValue(value, {
+        // emitEvent: false
+      });
     });
 
-    this.inputControl.setValue('why not?', { emitEvent: false });
-    this.rteControl.setValue('why not?', { emitEvent: false });
+    this.inputControl.setValue('i am input', {
+      emitEvent: false
+    });
+    this.rteControl.setValue('i am rte', {
+      emitEvent: false
+    });
   }
 }

--- a/projects/app-test/src/app/app.component.ts
+++ b/projects/app-test/src/app/app.component.ts
@@ -10,19 +10,20 @@ import { FormControl } from '@angular/forms';
 export class AppComponent implements OnInit {
   title = 'app-test';
 
-  rteControl = new FormControl('Test');
-  checkControl = new FormControl(true);
-  inputControl = new FormControl('blah');
+  rteControl = new FormControl();
+  inputControl = new FormControl();
 
   ngOnInit() {
-    this.rteControl.setValue('why not?');
-
     this.rteControl.valueChanges.subscribe(value => {
-      console.log('valueChanges', value);
+      console.log('RTE valueChanges', value);
     });
 
     this.inputControl.valueChanges.subscribe(value => {
-      this.rteControl.setValue(value);
+      console.log('INP valueChanges', value);
+      this.rteControl.setValue(value, { emitEvent: false });
     });
+
+    this.inputControl.setValue('why not?', { emitEvent: false });
+    this.rteControl.setValue('why not?', { emitEvent: false });
   }
 }

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rich-text-editor.component.ts
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rich-text-editor.component.ts
@@ -134,9 +134,8 @@ export class RichTextEditorComponent extends BaseFormElement
   }
 
   ngAfterViewInit(): void {
-    this.initEditor();
-
     setTimeout(() => {
+      this.initEditor();
       this.hasSuffix =
         this.suffix.nativeElement.children.length !== 0 ||
         this.suffix.nativeElement.childNodes.length !== 0
@@ -163,10 +162,6 @@ export class RichTextEditorComponent extends BaseFormElement
 
     this.editor = new quillLib(this.quillEditor.nativeElement, editorOptions);
 
-    if (!!this.value) {
-      this.applyValue(this.value);
-    }
-
     this.editor.enable(!this.disabled);
 
     this.editor.on('text-change', () => {
@@ -180,6 +175,10 @@ export class RichTextEditorComponent extends BaseFormElement
         this.changed.emit(newOutputValue);
       }
     });
+
+    if (!!this.value) {
+      this.applyValue(this.value);
+    }
 
     this.editor.on('selection-change', range => {
       if (range) {

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rich-text-editor.component.ts
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rich-text-editor.component.ts
@@ -116,6 +116,7 @@ export class RichTextEditorComponent extends BaseFormElement
   hasSuffix = true;
   hasSizeSet = false;
   private latestOutputValue: RteCurrentContent;
+  private writingValue = false;
 
   buttonType = ButtonType;
   icons = Icons;
@@ -171,8 +172,11 @@ export class RichTextEditorComponent extends BaseFormElement
         this.latestOutputValue.body !== newOutputValue.body
       ) {
         this.latestOutputValue = newOutputValue;
-        this.propagateChange(newOutputValue);
         this.changed.emit(newOutputValue);
+        if (!this.writingValue) {
+          this.propagateChange(newOutputValue);
+        }
+        this.writingValue = false;
       }
     });
 
@@ -213,6 +217,7 @@ export class RichTextEditorComponent extends BaseFormElement
   }
 
   writeValue(val: string): void {
+    this.writingValue = true;
     this.applyValue(val);
   }
 


### PR DESCRIPTION
invokes propagateChange with data object only if change comes from the editor or [input], and not from writevalue (with form control)