### PR TITLE
side menu three dots fix

### DIFF
--- a/projects/ui-framework/src/lib/navigation/side-menu/side-menu-option/side-menu-option.component.html
+++ b/projects/ui-framework/src/lib/navigation/side-menu/side-menu-option/side-menu-option.component.html
@@ -12,9 +12,8 @@
          *ngIf="option.actions?.length"
          [ngStyle]="{'opacity': (showActions || selected) ? 1 : 0}">
         <b-menu [menu]="option.actions"
-                (click)="stopBubbling($event)"
-                (mouseleave)="stopBubbling($event); setShowActions(true)"
-                (closeMenu)="showActions = false">
+                (click)="stopBubbling($event); setShowActions(true, 25)"
+                (closeMenu)="setShowActions(false)">
             <b-square-button menu-trigger
                              [type]="types.tertiary"
                              [icon]="icons.three_dots_vert"

--- a/projects/ui-framework/src/lib/navigation/side-menu/side-menu-option/side-menu-option.component.spec.ts
+++ b/projects/ui-framework/src/lib/navigation/side-menu/side-menu-option/side-menu-option.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { DebugElement, NO_ERRORS_SCHEMA, SimpleChanges } from '@angular/core';
 import { SideMenuOptionComponent } from './side-menu-option.component';
 import { getSideMenuOptionsMock } from '../side-menu.mock';
@@ -96,5 +96,13 @@ describe('SideMenuOptionComponent', () => {
     it('should display option-action if actions provided', () => {
       expect(optionActions.nativeElement).toBeTruthy();
     });
+    it('should set option-actions opacity to 1 when opening menu', fakeAsync(() => {
+      const bMenu = fixture.debugElement.query(By.css('b-menu'));
+      component.setShowActions(false);
+      bMenu.triggerEventHandler('click', null);
+      tick(25);
+      fixture.detectChanges();
+      expect(optionActions.nativeElement.style.opacity).toEqual('1');
+    }));
   });
 });

--- a/projects/ui-framework/src/lib/navigation/side-menu/side-menu-option/side-menu-option.component.ts
+++ b/projects/ui-framework/src/lib/navigation/side-menu/side-menu-option/side-menu-option.component.ts
@@ -75,8 +75,8 @@ export class SideMenuOptionComponent implements OnChanges {
     $event.stopPropagation();
   }
 
-  setShowActions(status: boolean): void {
-    setTimeout(() => this.showActions = status);
+  setShowActions(status: boolean, timeout: number = 0): void {
+    setTimeout(() => this.showActions = status, timeout);
   }
 
   onActionClick(): void {


### PR DESCRIPTION
when one item selected and you hover on the next one you will see '...' three dots, when you click on that three dots the panel opened and the three dots disappear, it shouldn't. i fixed it so it will not disappear.

