### PR TITLE
better RTE controls management

### DIFF
--- a/projects/app-test/src/app/form-elements/form-elements.component.html
+++ b/projects/app-test/src/app/form-elements/form-elements.component.html
@@ -2734,8 +2734,8 @@
                          [type]="bRTE_type"
                          [label]="bRTE_label"
                          [value]="bRTE_directValueInput ? bRTE_value : undefined"
-                         [controls]="RTE_controls"
-                         [disableControls]="RTE_disableControls"
+                         [controls]="bRTE_controls"
+                         [disableControls]="bRTE_disableControls"
                          [placeholderList]="bRTE_placeholderList"
                          [disabled]="bRTE_disabled"
                          [required]="bRTE_required"
@@ -2753,8 +2753,8 @@
                          [type]="bRTE_type"
                          [label]="bRTE_label"
                          [value]="bRTE_directValueInput ? bRTE_value : undefined"
-                         [controls]="RTE_controls"
-                         [disableControls]="RTE_disableControls"
+                         [controls]="bRTE_controls"
+                         [disableControls]="bRTE_disableControls"
                          [placeholderList]="bRTE_placeholderList"
                          [disabled]="bRTE_disabled"
                          [required]="bRTE_required"
@@ -2824,6 +2824,97 @@
      </p>
      <div class="outputValue full-width">
        {{ bRTE_EventValue }}
+     </div>
+
+     <p class="
+            full-width">
+       <strong>Controls prop</strong>
+     </p>
+
+     <div class="control-item col">
+       <label>
+         <textarea class="simple-textarea bigger"
+                   (change)="runComponentNgOnChanges('bRTE',
+                          arrayOfStringsOrArrayFromString($event.target.value), 'controls')"
+                   [value]="bRTE_controls"
+                   type="search"></textarea>
+       </label>
+       <div style="margin: 5px 0 0 0;justify-content: space-between;"
+            class="row">
+         <button type="button"
+                 style="padding: 0 2px; max-width: none;"
+                 class="small-button"
+                 (click)="bRTE_controls = getComponentProp('bRTE', 'controls')">
+           get
+         </button>
+         <button type="button"
+                 style="padding: 0 2px; max-width: none;"
+                 class="small-button"
+                 (click)="bRTE_controls = bRTE_controlsDef;">
+           set
+         </button>
+         <button type="button"
+                 style="padding: 0 2px; max-width: none;"
+                 class="small-button"
+                 (click)="bRTE_controls = [];">
+           []
+         </button>
+         <button type="button"
+                 style="padding: 0 2px; max-width: none;"
+                 class="small-button"
+                 (click)="bRTE_controls = null;">
+           null
+         </button>
+         <button type="button"
+                 style="padding: 0 2px; max-width: none;"
+                 class="small-button"
+                 (click)="bRTE_controls = undefined;">
+           undef
+         </button>
+       </div>
+     </div>
+
+     <div class="control-item col">
+       <label>
+         <textarea class="simple-textarea bigger"
+                   (change)="runComponentNgOnChanges('bRTE',
+                          arrayOfStringsOrArrayFromString($event.target.value), 'disableControls')"
+                   [value]="bRTE_disableControls"
+                   type="search"></textarea>
+       </label>
+       <div style="margin: 5px 0 0 0;justify-content: space-between;"
+            class="row">
+         <button type="button"
+                 style="padding: 0 2px; max-width: none;"
+                 class="small-button"
+                 (click)="bRTE_disableControls = getComponentProp('bRTE', 'disableControls')">
+           get
+         </button>
+         <button type="button"
+                 style="padding: 0 2px; max-width: none;"
+                 class="small-button"
+                 (click)="bRTE_disableControls = bRTE_disableControlsDef;">
+           set
+         </button>
+         <button type="button"
+                 style="padding: 0 2px; max-width: none;"
+                 class="small-button"
+                 (click)="bRTE_disableControls = [];">
+           []
+         </button>
+         <button type="button"
+                 style="padding: 0 2px; max-width: none;"
+                 class="small-button"
+                 (click)="bRTE_disableControls = null;">
+           null
+         </button>
+         <button type="button"
+                 style="padding: 0 2px; max-width: none;"
+                 class="small-button"
+                 (click)="bRTE_disableControls = undefined;">
+           undef
+         </button>
+       </div>
      </div>
 
      <div class="control-item col">

--- a/projects/app-test/src/app/form-elements/form-elements.component.ts
+++ b/projects/app-test/src/app/form-elements/form-elements.component.ts
@@ -655,9 +655,9 @@ export class FormElementsTestComponent
     }
   ];
 
-  disableControlsDef = [BlotType.align, BlotType.direction];
-  controlsDef = Object.values(BlotType).filter(
-    cntrl => !this.disableControlsDef.includes(cntrl)
+  bRTE_disableControlsDef = [BlotType.align, BlotType.direction];
+  bRTE_controlsDef = Object.values(BlotType).filter(
+    cntrl => !this.bRTE_disableControlsDef.includes(cntrl)
   );
 
   @ViewChild('bRTE') private bRTE_component;
@@ -670,8 +670,8 @@ export class FormElementsTestComponent
   bRTE_type = 'primary';
   bRTE_value = this.RTEvalueMock;
 
-  RTE_controls = this.controlsDef;
-  RTE_disableControls = this.disableControlsDef;
+  bRTE_controls = this.bRTE_controlsDef;
+  bRTE_disableControls  = this.bRTE_disableControlsDef;
   bRTE_placeholderList = this.placeholderMock;
 
   bRTE_label = 'Rich text label';
@@ -729,13 +729,13 @@ export class FormElementsTestComponent
     }
   }
 
-  runComponentNgOnChanges(name, value: any = NaN) {
+  runComponentNgOnChanges(name, value: any = NaN, prop = 'value') {
     if (value !== value) {
       value = this[name + '_value'];
     }
     // this[name + '_component'].value = value;
     this[name + '_component'].ngOnChanges({
-      value: new SimpleChange(null, value, false)
+      [prop]: new SimpleChange(null, value, false)
     });
   }
 
@@ -745,6 +745,12 @@ export class FormElementsTestComponent
     }
     if (this[name + '_component']) {
       this[name + '_component'][prop] = value;
+    }
+  }
+
+  getComponentProp(name, prop = 'value') {
+    if (this[name + '_component']) {
+      return this[name + '_component'][prop]
     }
   }
 
@@ -758,7 +764,7 @@ export class FormElementsTestComponent
         if (this.global_consoleLog) {
           console.log('--------<<<<<<<<-----------');
           console.log(
-            'Setting value of ' + name + ' to ' + (getType(val)) + ':',
+            'Setting value of ' + name + ' to ' + getType(val) + ':',
             val
           );
         }
@@ -1002,7 +1008,7 @@ export class FormElementsTestComponent
     this.subscribeToAll(this.allFormElements);
 
     // this.hideComponents(this.allFormElements);
-    // this.showComponents(['bDatepicker']);
+    // this.showComponents(['bRTE']);
 
     // 'bInput'
     // 'bTextarea'

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-core/rte-form-element.abstract.ts
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-core/rte-form-element.abstract.ts
@@ -197,11 +197,16 @@ export abstract class RTEformElement extends BaseFormElement
         this.editor.enable(!this.disabled);
       }
     }
+    if (changes.placeholder) {
+      this.placeholder = changes.placeholder.currentValue;
+    }
     if (changes.label) {
       this.label = changes.label.currentValue;
+    }
+    if (changes.placeholder || changes.label) {
       this.rteUtils.setEditorPlaceholder(
         this.editor,
-        this.label,
+        this.placeholder || this.label,
         this.required
       );
     }
@@ -209,7 +214,7 @@ export abstract class RTEformElement extends BaseFormElement
       this.required = changes.required.currentValue;
       this.rteUtils.setEditorPlaceholder(
         this.editor,
-        this.label,
+        this.placeholder || this.label,
         this.required
       );
     }

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-core/rte-form-element.abstract.ts
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-core/rte-form-element.abstract.ts
@@ -39,16 +39,21 @@ export abstract class RTEformElement extends BaseFormElement
     super();
   }
 
+  public controlsDef = Object.values(BlotType);
+  public disableControlsDef = [];
+
   @Input() public value: string;
   @Input() public minChars = 0;
   @Input() public maxChars: number;
-  @Input() public controls: BlotType[] = Object.values(BlotType);
-  @Input() public disableControls: BlotType[] = [];
+  @Input() public controls: BlotType[] = this.controlsDef;
+  @Input() public disableControls: BlotType[] = this.disableControlsDef;
   @Input() public sendChangeOn: RTEchangeEvent = RTEchangeEvent.blur;
   @Input() private formControlName: any;
   @Input() private formControl: any;
 
   @ViewChild('quillEditor') protected quillEditor: ElementRef;
+  @ViewChild('toolbar') protected toolbar: ElementRef;
+  @ViewChild('suffix') protected suffix: ElementRef;
   @ViewChild('sizePanel') protected sizePanel: PanelComponent;
 
   @Output() blurred: EventEmitter<any> = new EventEmitter<any>();
@@ -159,11 +164,15 @@ export abstract class RTEformElement extends BaseFormElement
 
   private onControlChanges(changes: SimpleChanges) {
     if (changes.controls) {
-      this.controls = changes.controls.currentValue;
+      this.controls = changes.controls.currentValue || this.controlsDef;
     }
     if (changes.disableControls) {
-      this.disableControls = changes.disableControls.currentValue;
-      if (changes.disableControls.previousValue) {
+      this.disableControls =
+        changes.disableControls.currentValue || this.disableControlsDef;
+      if (
+        changes.disableControls.previousValue &&
+        (this.controls && this.controls.length !== 0)
+      ) {
         this.controls = this.controls.concat(
           changes.disableControls.previousValue
         );
@@ -176,6 +185,7 @@ export abstract class RTEformElement extends BaseFormElement
       if (this.editor) {
         (this.editor as any).options.formats = Object.values(this.controls);
       }
+
       this.updateSpecialBlots();
     }
   }

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-core/rte-form-element.abstract.ts
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-core/rte-form-element.abstract.ts
@@ -203,21 +203,17 @@ export abstract class RTEformElement extends BaseFormElement
     if (changes.label) {
       this.label = changes.label.currentValue;
     }
-    if (changes.placeholder || changes.label) {
-      this.rteUtils.setEditorPlaceholder(
-        this.editor,
-        this.placeholder || this.label,
-        this.required
-      );
-    }
     if (changes.required) {
       this.required = changes.required.currentValue;
+    }
+    if (changes.placeholder || changes.label || changes.required) {
       this.rteUtils.setEditorPlaceholder(
         this.editor,
         this.placeholder || this.label,
-        this.required
+        this.required && this.placeholder && this.label ? false : this.required
       );
     }
+
     this.onControlChanges(changes);
 
     this.onNgChanges(changes);

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-link/rte-link-editor.component.scss
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-link/rte-link-editor.component.scss
@@ -3,7 +3,7 @@
 :host {
   display: block;
   min-width: 350px;
-  max-width: 390px;
+  max-width: 95vw;
 }
 
 :host ::ng-deep {

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-link/rte-link-editor.component.scss
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-link/rte-link-editor.component.scss
@@ -1,4 +1,8 @@
+@import '../../../style/variables';
+
 :host {
+  display: block;
+  min-width: 350px;
   max-width: 390px;
 }
 
@@ -29,4 +33,11 @@
 
 .cancel {
   margin-right: 4px;
+}
+
+::ng-deep {
+  .b-panel.rte-link-editor-panel {
+    display: flex;
+    justify-content: center;
+  }
 }

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-placeholder/rte-placeholders.scss
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-placeholder/rte-placeholders.scss
@@ -36,7 +36,7 @@ $border-color: var(--negative-700);
     font-size: 96%;
     padding-top: 2px;
     filter: grayscale(1);
-    opacity: 0.7;
+    opacity: 0.75;
 
     &:hover,
     &:focus {

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-placeholder/rte-placeholders.scss
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-placeholder/rte-placeholders.scss
@@ -52,7 +52,7 @@ $border-color: var(--negative-700);
     b-single-list {
       border: 0;
       min-width: 350px;
-      max-width: 390px;
+      max-width: 95vw;
 
       &:hover {
         box-shadow: none;

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-placeholder/rte-placeholders.scss
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-placeholder/rte-placeholders.scss
@@ -44,14 +44,15 @@ $border-color: var(--negative-700);
 }
 
 ::ng-deep {
-  .placeholder-rte-panel {
-    .panel-position .panel-wrapper {
+  .b-panel.placeholder-rte-panel {
+    .panel-wrapper {
       padding: 0;
     }
+
     b-single-list {
       border: 0;
-      display: block;
-      min-width: 400px;
+      min-width: 350px;
+      max-width: 390px;
 
       &:hover {
         box-shadow: none;

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-placeholder/rte-placeholders.scss
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte-placeholder/rte-placeholders.scss
@@ -31,6 +31,18 @@ $border-color: var(--negative-700);
       @include position(0 null 0 0);
     }
   }
+
+  .placeholder-panel [panel-trigger] {
+    font-size: 96%;
+    padding-top: 2px;
+    filter: grayscale(1);
+    opacity: 0.7;
+
+    &:hover,
+    &:focus {
+      opacity: 1;
+    }
+  }
 }
 
 :host.disabled ::ng-deep {

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.html
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.html
@@ -1,4 +1,9 @@
-<div class="quill-editor">
+<label *ngIf="label && placeholder"
+       class="bfe-label"
+       [attr.for]="id">{{label}}</label>
+
+<div class="quill-editor"
+     [attr.id]="id">
   <div #quillEditor
        [attr.data-length]="(minChars > 0 || maxChars) ? ( (length || 0) + (maxChars ? '/' + maxChars : '')) : null"
        (keydown)="$event.stopPropagation()"

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.html
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.html
@@ -5,9 +5,11 @@
 <div class="quill-editor"
      [attr.id]="id">
   <div #quillEditor
-       [attr.data-length]="(minChars > 0 || maxChars) ? ( (length || 0) + (maxChars ? '/' + maxChars : '')) : null"
+       [attr.data-length]="hasSuffix && (minChars > 0 || maxChars) ? ( (length || 0) + (maxChars ? '/' + maxChars : '')) :
+       null"
        (keydown)="$event.stopPropagation()"
-       [ngClass]="{'length-invalid': length < minChars || (maxChars && length > maxChars)}"
+       [ngClass]="{'length-invalid': hasSuffix && (length < minChars
+         || (maxChars && length > maxChars))}"
        [ngStyle]="{
          minHeight: minHeight ? (minHeight - 43) + 'px' : null,
          maxHeight: maxHeight ? (maxHeight - 43) + 'px' : null
@@ -123,12 +125,24 @@
       <ng-content></ng-content>
     </div>
 
+    <span class="length-indicator"
+          *ngIf="!hasSuffix && (minChars > 0 || maxChars)"
+          [ngClass]="{'length-invalid': length < minChars ||
+            (maxChars && length > maxChars)}">
+      {{ (length || 0) + (maxChars ? '/' + maxChars : '') }}
+    </span>
+
   </div>
 
 </div>
 
 <p b-input-message
-   *ngIf="hintMessage || warnMessage || errorMessage"
+   *ngIf="
+          hintMessage
+          ||
+          warnMessage
+          ||
+          errorMessage"
    [hintMessage]="hintMessage"
    [warnMessage]="warnMessage"
    [errorMessage]="errorMessage"

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.html
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.html
@@ -61,7 +61,7 @@
             [hidden]="!controls.includes(BlotType.underline)"></button>
 
     <b-panel #linkPanel
-             panelClass="rte-link-editor"
+             panelClass="rte-link-editor-panel"
              [showBackdrop]="false"
              [size]="panelSize.medium"
              [hidden]="!controls.includes(BlotType.link)"

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.html
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.html
@@ -109,7 +109,7 @@
              [defaultPosVer]="panelDefaultPosVer.below"
              (closed)="restoreSelection()">
       <button (click)="onPlaceholderPanelOpen()"
-              panel-trigger>rte</button>
+              panel-trigger>💊</button>
       <b-single-list #placeholderSelect
                      panel-content
                      class="single-list-select"

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.html
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.html
@@ -11,8 +11,7 @@
 
   <div #toolbar
        class="quill-toolbar"
-       [attr.hide-align]="!controls.includes(BlotType.align)"
-       *ngIf="controls.length > 0 || hasSuffix"
+       [hidden]="controls.length === 0 && !hasSuffix"
        (mousedown)="$event.preventDefault()">
 
     <b-panel #sizePanel
@@ -50,17 +49,17 @@
     </b-panel>
 
     <button class="ql-bold"
-            *ngIf="controls.includes(BlotType.bold)"></button>
+            [hidden]="!controls.includes(BlotType.bold)"></button>
     <button class="ql-italic"
-            *ngIf="controls.includes(BlotType.italic)"></button>
+            [hidden]="!controls.includes(BlotType.italic)"></button>
     <button class="ql-underline"
-            *ngIf="controls.includes(BlotType.underline)"></button>
+            [hidden]="!controls.includes(BlotType.underline)"></button>
 
     <b-panel #linkPanel
              panelClass="rte-link-editor"
              [showBackdrop]="false"
              [size]="panelSize.medium"
-             *ngIf="controls.includes(BlotType.link)"
+             [hidden]="!controls.includes(BlotType.link)"
              [defaultPosVer]="panelDefaultPosVer.below"
              (closed)="restoreSelection()">
       <button class="ql-link"
@@ -75,14 +74,14 @@
     <button type="button"
             class="ql-list"
             value="ordered"
-            *ngIf="controls.includes(BlotType.list)"></button>
+            [hidden]="!controls.includes(BlotType.list)"></button>
     <button type="button"
             class="ql-list"
             value="bullet"
-            *ngIf="controls.includes(BlotType.list)"></button>
+            [hidden]="!controls.includes(BlotType.list)"></button>
 
     <select class="ql-align"
-            *ngIf="controls.includes(BlotType.align)">
+            [hidden]="!controls.includes(BlotType.align)">
       <option selected></option>
       <option value="center"></option>
       <option value="right"></option>
@@ -92,7 +91,7 @@
     <button type="button"
             class="ql-direction"
             value="rtl"
-            *ngIf="controls.includes(BlotType.direction)"></button>
+            [hidden]="!controls.includes(BlotType.direction)"></button>
 
     <b-panel #placeholderPanel
              class="placeholder-panel"

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.spec.ts
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.spec.ts
@@ -41,13 +41,13 @@ import { Platform } from '@angular/cdk/platform';
 import { DOMhelpers } from '../../services/utils/dom-helpers.service';
 import { PlaceholderRteConverterService } from './rte-placeholder/placeholder-rte-converter.service';
 import { InputMessageModule } from '../input-message/input-message.module';
-import { not } from '@angular/compiler/src/output/output_ast';
 
 @Component({
   template: `
     <form class="form" [formGroup]="rteForm">
       <b-rich-text-editor
         [label]="'label text'"
+        [placeholder]="'placeholder text'"
         formControlName="rteControl"
       ></b-rich-text-editor>
     </form>
@@ -75,7 +75,7 @@ class TestComponent implements OnInit, OnDestroy {
   }
 }
 
-describe('RichTextEditorComponent', () => {
+fdescribe('RichTextEditorComponent', () => {
   let fixture: ComponentFixture<TestComponent>;
   let testComponent: TestComponent;
 
@@ -208,6 +208,17 @@ describe('RichTextEditorComponent', () => {
         'test label *'
       );
     });
+
+    // it('should put', () => {
+    //   RTEComponent.ngOnChanges({
+    //     label: new SimpleChange(null, 'test label', false)
+    //   });
+    //   fixture.detectChanges();
+
+    //   expect(RTEqlEditorNativeElement.getAttribute('data-placeholder')).toEqual(
+    //     'test label'
+    //   );
+    // });
 
     it('should insert hintMessage text', () => {
       RTEComponent.hintMessage = 'test hint';

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.spec.ts
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.spec.ts
@@ -75,7 +75,7 @@ class TestComponent implements OnInit, OnDestroy {
   }
 }
 
-fdescribe('RichTextEditorComponent', () => {
+describe('RichTextEditorComponent', () => {
   let fixture: ComponentFixture<TestComponent>;
   let testComponent: TestComponent;
 
@@ -180,53 +180,95 @@ fdescribe('RichTextEditorComponent', () => {
       );
     });
 
-    it('should insert label placeholder text', () => {
+    it('should insert hintMessage text', () => {
+      RTEComponent.hintMessage = 'test hint';
+      fixture.detectChanges();
+
+      const messageElement = fixture.debugElement.query(
+        By.css('[b-input-message]')
+      ).nativeElement;
+      expect(messageElement.innerText).toEqual('test hint');
+    });
+
+    it('should insert warnMessage text over hintMessage text', () => {
+      RTEComponent.hintMessage = 'test hint';
+      RTEComponent.warnMessage = 'test warn';
+      fixture.detectChanges();
+
+      const messageElement = fixture.debugElement.query(
+        By.css('[b-input-message]')
+      ).nativeElement;
+      expect(messageElement.innerText).toEqual('test warn');
+    });
+  });
+
+  describe('Label & placeholder', () => {
+    it('should insert placeholder text', () => {
+      expect(RTEqlEditorNativeElement.getAttribute('data-placeholder')).toEqual(
+        'placeholder text'
+      );
+    });
+
+    it('should update placeholder text', () => {
+      RTEComponent.ngOnChanges({
+        placeholder: new SimpleChange(null, 'test placeholder', false)
+      });
+      fixture.detectChanges();
+
+      expect(RTEqlEditorNativeElement.getAttribute('data-placeholder')).toEqual(
+        'test placeholder'
+      );
+    });
+
+    it('should insert label text', () => {
+      const labelElem = fixture.debugElement.query(By.css('.bfe-label'))
+        .nativeElement;
+      expect(labelElem.innerText).toEqual('label text');
+    });
+
+    it('should insert label text into placeholder slot if no placeholder text provided', () => {
+      RTEComponent.ngOnChanges({
+        placeholder: new SimpleChange(null, undefined, false)
+      });
+      fixture.detectChanges();
+
+      const labelElem = fixture.debugElement.query(By.css('.bfe-label'));
+
+      expect(labelElem).toBeFalsy();
       expect(RTEqlEditorNativeElement.getAttribute('data-placeholder')).toEqual(
         'label text'
       );
     });
 
-    it('should update label placeholder text', () => {
+    it('should add * to placeholder text, when required is true and no label provided', () => {
       RTEComponent.ngOnChanges({
-        label: new SimpleChange(null, 'test label', false)
-      });
-      fixture.detectChanges();
-
-      expect(RTEqlEditorNativeElement.getAttribute('data-placeholder')).toEqual(
-        'test label'
-      );
-    });
-
-    it('should add * to placeholder text, when required is true', () => {
-      RTEComponent.ngOnChanges({
-        label: new SimpleChange(null, 'test label', false),
+        label: new SimpleChange(null, undefined, false),
         required: new SimpleChange(null, true, false)
       });
       fixture.detectChanges();
 
       expect(RTEqlEditorNativeElement.getAttribute('data-placeholder')).toEqual(
-        'test label *'
+        'placeholder text *'
       );
     });
 
-    // it('should put', () => {
-    //   RTEComponent.ngOnChanges({
-    //     label: new SimpleChange(null, 'test label', false)
-    //   });
-    //   fixture.detectChanges();
-
-    //   expect(RTEqlEditorNativeElement.getAttribute('data-placeholder')).toEqual(
-    //     'test label'
-    //   );
-    // });
-
-    it('should insert hintMessage text', () => {
-      RTEComponent.hintMessage = 'test hint';
+    it('should add * to label text, and not placeholder, when required is true and both label and placeholder provided', () => {
+      RTEComponent.ngOnChanges({
+        required: new SimpleChange(null, true, false)
+      });
       fixture.detectChanges();
 
-      const hintNativeElement = fixture.debugElement.query(By.css('.hint'))
+      expect(RTEqlEditorNativeElement.getAttribute('data-placeholder')).toEqual(
+        'placeholder text'
+      );
+      const labelElem = fixture.debugElement.query(By.css('.bfe-label'))
         .nativeElement;
-      expect(hintNativeElement.innerText).toEqual('test hint');
+
+      const labelBeforeStyle = window.getComputedStyle(labelElem, '::after');
+      const labelBeforeText = labelBeforeStyle.getPropertyValue('content');
+
+      expect(labelElem.innerText).toEqual('label text');
+      expect(labelBeforeText).toContain('*');
     });
   });
 

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.spec.ts
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.spec.ts
@@ -41,6 +41,7 @@ import { Platform } from '@angular/cdk/platform';
 import { DOMhelpers } from '../../services/utils/dom-helpers.service';
 import { PlaceholderRteConverterService } from './rte-placeholder/placeholder-rte-converter.service';
 import { InputMessageModule } from '../input-message/input-message.module';
+import { not } from '@angular/compiler/src/output/output_ast';
 
 @Component({
   template: `
@@ -136,10 +137,10 @@ describe('RichTextEditorComponent', () => {
         rteControl = testComponent.rteForm.get('rteControl');
 
         RTEComponent.ngOnChanges({
-          controls: new SimpleChange(null, RTEComponent.controls, true),
+          controls: new SimpleChange(null, RTEComponent.controlsDef, true),
           disableControls: new SimpleChange(
             null,
-            RTEComponent.disableControls,
+            RTEComponent.disableControlsDef,
             true
           )
         });
@@ -282,15 +283,10 @@ describe('RichTextEditorComponent', () => {
     it('should display toolbar with controls present in controls array', () => {
       RTEComponent.controls = [BlotType.bold, BlotType.italic];
       fixture.detectChanges();
-
-      const toolbarElement = fixture.debugElement.query(
-        By.css('.quill-toolbar')
-      ).nativeElement;
-
-      expect(toolbarElement.children.length).toEqual(3);
-      expect(toolbarElement.children[0].className).toContain('ql-bold');
-      expect(toolbarElement.children[1].className).toContain('ql-italic');
-      expect(toolbarElement.children[2].nodeName).toEqual('SPAN');
+      const controlElems = fixture.debugElement.queryAll(
+        By.css('.quill-toolbar > [class*="ql-"]:not([hidden])')
+      );
+      expect(controlElems.length).toEqual(2);
     });
   });
 
@@ -337,7 +333,7 @@ describe('RichTextEditorComponent', () => {
       linkButtonElement.click();
 
       const linkPanelElement = overlayContainerElement.querySelector(
-        '.b-panel.rte-link-editor'
+        '.b-panel.rte-link-editor-panel'
       ) as HTMLElement;
 
       expect(linkPanelElement).toBeTruthy();

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.ts
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.ts
@@ -79,14 +79,15 @@ export class RichTextEditorComponent extends RTEformElement
     super(rteUtils, changeDetector, injector);
   }
 
-  @Input() public type: RTEType = RTEType.primary;
-  @Input() public minHeight = 185;
-  @Input() public maxHeight = 295;
-  @Input() public disableControls: BlotType[] = [
+  public disableControlsDef = [
     BlotType.placeholder,
     BlotType.align,
     BlotType.direction
   ];
+
+  @Input() public type: RTEType = RTEType.primary;
+  @Input() public minHeight = 185;
+  @Input() public maxHeight = 295;
 
   @HostBinding('class.rte-primary') get isOfTypePrimary(): boolean {
     return !this.type || this.type === RTEType.primary;
@@ -97,9 +98,6 @@ export class RichTextEditorComponent extends RTEformElement
   @HostBinding('class.rte-tertiary') get isOfTypeTertiary(): boolean {
     return this.type === RTEType.tertiary;
   }
-
-  @ViewChild('toolbar') private toolbar: ElementRef;
-  @ViewChild('suffix') private suffix: ElementRef;
 
   public hasSuffix = true;
   readonly buttonType = ButtonType;

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.ts
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.ts
@@ -166,7 +166,7 @@ export class RichTextEditorComponent extends RTEformElement
     merge(this.editorOptions, {
       placeholder: this.rteUtils.getEditorPlaceholder(
         this.placeholder || this.label,
-        this.required
+        this.required && this.placeholder && this.label ? false : this.required
       ),
       modules: {
         toolbar: {

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.ts
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.component.ts
@@ -7,7 +7,6 @@ import {
   ViewChild,
   HostBinding,
   Input,
-  ElementRef,
   SimpleChanges
 } from '@angular/core';
 import { NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -166,7 +165,7 @@ export class RichTextEditorComponent extends RTEformElement
   onNgAfterViewInit(): void {
     merge(this.editorOptions, {
       placeholder: this.rteUtils.getEditorPlaceholder(
-        this.label,
+        this.placeholder || this.label,
         this.required
       ),
       modules: {

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.scss
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.scss
@@ -32,6 +32,12 @@ $border-color: $grey-500;
   &:not(.ql-toolbar) {
     opacity: 0;
   }
+
+  &[hidden],
+  [hidden] {
+    display: none !important;
+    pointer-events: none;
+  }
 }
 
 :host ::ng-deep {
@@ -424,14 +430,6 @@ $border-color: $grey-500;
         @include BodyFont(32px, $lineHeight: 1);
       }
     }
-  }
-}
-
-// Align panel
-
-.quill-toolbar[hide-align='true'] ::ng-deep {
-  .ql-align {
-    display: none;
   }
 }
 

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.scss
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.scss
@@ -21,6 +21,10 @@ $border-color: $grey-500;
   @include form-element-margins;
 }
 
+.bfe-label {
+  @include bFormElement-label;
+}
+
 .quill-editor {
   display: flex;
   flex-direction: column;

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.scss
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.scss
@@ -259,6 +259,16 @@ $border-color: $grey-500;
   }
 }
 
+.length-indicator {
+  font-size: $font-size-caption;
+  color: $grey-600;
+  margin-left: auto;
+
+  &.length-invalid {
+    color: $color-error;
+  }
+}
+
 // Disabled
 
 :host {

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.scss
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.scss
@@ -379,7 +379,7 @@ $border-color: $grey-500;
 
 ::ng-deep {
   .b-panel.rte-size-controls,
-  .b-panel.rte-link-editor,
+  .b-panel.rte-link-editor-panel,
   .b-panel.placeholder-rte-panel {
     margin-top: -3px;
 

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.scss
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.scss
@@ -24,6 +24,11 @@ $border-color: $grey-500;
 .bfe-label {
   @include bFormElement-label;
 }
+:host.required {
+  .bfe-label {
+    @include input-requred;
+  }
+}
 
 .quill-editor {
   display: flex;

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.stories.ts
@@ -43,6 +43,7 @@ const template = `
       [disabled]="disabled"
       [required]="required"
       [hintMessage]="hintMessage"
+      [warnMessage]="warnMessage"
       [errorMessage]="errorMessage"
       (changed)="change($event)"
       (focused)="focus($event)"
@@ -140,6 +141,7 @@ inputStories.add(
         disabled: boolean('disabled', false),
         required: boolean('required', false),
         hintMessage: text('hintMessage', 'This field should contain something'),
+        warnMessage: text('warnMessage', ''),
         errorMessage: text('errorMessage', ''),
         change: action('Something has changed'),
         focus: action('Editor focused'),

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.stories.ts
@@ -47,7 +47,6 @@ const template = `
       (changed)="change($event)"
       (focused)="focus($event)"
       (blurred)="blur($event)">
-    Some custom toolbar thing
   </b-rich-text-editor>
 `;
 
@@ -114,11 +113,7 @@ const placeholderMock = [
   }
 ];
 
-const disableControlsDef = [
-  // BlotType.color,
-  BlotType.align,
-  BlotType.direction
-];
+const disableControlsDef = [BlotType.align, BlotType.direction];
 const controlsDef = values(BlotType).filter(
   cntrl => !disableControlsDef.includes(cntrl)
 );

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.stories.ts
@@ -31,6 +31,7 @@ const template = `
   <b-rich-text-editor
       [type]="type"
       [label]="label"
+      [placeholder]="placeholder"
       [value]="value"
       [controls]="controls"
       [disableControls]="disableControls"
@@ -129,7 +130,8 @@ inputStories.add(
       template: storyTemplate,
       props: {
         type: select('type', values(RTEType), RTEType.primary),
-        label: text('label', 'Compose an epic...'),
+        placeholder: text('placeholder', 'Compose an epic...'),
+        label: text('label', 'Edit rich textor'),
         value: text('value', value),
         controls: array('controls', controlsDef, '\n'),
         disableControls: array('disableControls', disableControlsDef, '\n'),

--- a/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/rich-text-editor/rte.stories.ts
@@ -74,9 +74,10 @@ const note = `
   Name | Type | Description | default
   --- | --- | --- | ---
   type | RTEType | primary (white bg, border) or secondary (transparent bg, no borders) | primary
-  label | string | placeholder text | none (optional)
+  label | string | label text (above editor) | none (optional)
+  placeholder | string | placeholder text (inside editor. if only label is present, it will be treated as placeholder) | none (optional)
   value | string | html content to be placed inside editor | none (optional)
-  controls | BlotType[] | array of toolbar controls. Possible controls: size, bold, italic, underline, link, list, align, dir. Defaults to all controls. Pass empty array to disable all controls. | all
+  controls | BlotType[] | array of toolbar controls (check BlotType enum for all possible controls). Defaults to all controls. Pass empty array to disable all controls | all
   minChars | number | minimum (plain) text length | 0
   maxChars | number | maximum (plain) text length | none (optional)
   minHeight | number | minimum height of editor (including toolbar). Set to null or 0 to disable min-height | 185 (optional)
@@ -84,7 +85,8 @@ const note = `
   disabled | boolean | disables editor | false (optional)
   required | boolean | adds * to placeholder | false (optional)
   hintMessage | string | adds a hint message below editor | none (optional)
-  errorMessage | string | adds 'invalid' style, hides hint message and displays error message below editor | none (optional)
+  warnMessage | string | adds a warning message below editor | none (optional)
+  errorMessage | string | adds 'invalid' style, hides hint/warn message and displays error message below editor | none (optional)
   sendChangeOn | RTEchangeEvent | When to transmit value changes - on change (every keystroke) or on blur | blur (optional)
   changed | function | change event handler (event transmits latest change: {body,plainText}) |
   focused | function | focus event handler (event transmits latest change: {body,plainText}) |

--- a/projects/ui-framework/src/lib/layout/sectionContainer/sectionContainer.component.spec.ts
+++ b/projects/ui-framework/src/lib/layout/sectionContainer/sectionContainer.component.spec.ts
@@ -24,7 +24,7 @@ class TestComponent {
   constructor() {}
 }
 
-fdescribe('SectionContainerComponent', () => {
+describe('SectionContainerComponent', () => {
   let fixture: ComponentFixture<TestComponent>;
   let component: TestComponent;
   let collapsibleComponent: SectionContainerComponent;

--- a/projects/ui-framework/src/lib/popups/panel/panel.enum.ts
+++ b/projects/ui-framework/src/lib/popups/panel/panel.enum.ts
@@ -1,10 +1,10 @@
 export enum PanelSize {
   small = 'small',
   medium = 'medium',
-  large = 'large',
+  large = 'large'
 }
 
 export enum PanelDefaultPosVer {
   above = 'above',
-  below = 'below',
+  below = 'below'
 }


### PR DESCRIPTION
- if no controls/disableControls input is provided, use defaults
- controls can be enabled/disabled dynamically

And while I was there:
- Added label above RTE. the label inside is now placeholder. if only 1 of 2 is present, it will be treated as placeholder (for backwards compatibility).
- fixed panels width (kind of)
- moved chars counter to toolbar suffix