### PR TITLE
list change: add getSelected method

### DIFF
--- a/projects/ui-framework/src/lib/form-elements/lists/list-change/list-change.spec.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/list-change/list-change.spec.ts
@@ -43,4 +43,21 @@ describe('ListChange', () => {
       expect(listChange.getSelectedIds()).toEqual([1, 11]);
     });
   });
+
+  describe('getSelected', () => {
+    it('should return empty array when non are selected', () => {
+      listChange = new ListChange(optionsMock);
+      expect(listChange.getSelected()).toEqual([]);
+    });
+    it('should return selected option ids with group name', () => {
+      optionsMock[0].options[0].selected = true;
+      optionsMock[1].options[0].selected = true;
+      listChange = new ListChange(optionsMock);
+      expect(listChange.getSelected()).toEqual([{
+        id: 1, groupName: 'Basic Info',
+      }, {
+        id: 11, groupName: 'Personal',
+      }]);
+    });
+  });
 });

--- a/projects/ui-framework/src/lib/form-elements/lists/list-change/list-change.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/list-change/list-change.ts
@@ -1,4 +1,4 @@
-import { chain } from 'lodash';
+import { chain, concat, map } from 'lodash';
 import { SelectGroupOption } from '../list.interface';
 
 export class ListChange {
@@ -19,6 +19,21 @@ export class ListChange {
       .flatMap('options')
       .filter(o => o.selected)
       .flatMap('id')
+      .value();
+  }
+
+  getSelected(): { id: number | string; groupName: string }[] {
+    return chain(this.selectGroupOptions)
+      .reduce(
+        (selected, group) =>
+          concat(
+            selected,
+            map(group.options, option => ({ option,  groupName: group.groupName }))
+          ),
+        [],
+      )
+      .filter(groupOption => groupOption.option.selected)
+      .map(groupOption => ({ id: groupOption.option.id, groupName: groupOption.groupName }))
       .value();
   }
 }


### PR DESCRIPTION
For grouped select elements it is often useful to know the selected option's group name, along with the option ID.
I've added a method to `ListChange` to do just that.