### PR TITLE
avatar & tooltip update

### DIFF
--- a/projects/ui-framework/src/lib/buttons-indicators/avatar/avatar-variants.scss
+++ b/projects/ui-framework/src/lib/buttons-indicators/avatar/avatar-variants.scss
@@ -2,12 +2,12 @@
 @import '../../style/mixins';
 @import '../../style/typography';
 
-:host.mini {
+:host[data-size='mini'] {
   .avatar {
     box-shadow: 0 1px 2px 0 $boxShadowColor;
     border-width: 2px;
   }
-  &.clickable .avatar:hover {
+  &[data-clickable='true'] .avatar:hover {
     box-shadow: 0 3px 6px 0 $boxShadowColor;
   }
   .avatar-badge {
@@ -31,13 +31,13 @@
   .slot2-medium {
     @include BodyFont($font-size-body, null, null, $addCssVars: true);
   }
-  &.horizontal {
+  &[data-orientation='horizontal'] {
     .avatar-text {
       margin-left: 5px;
       max-width: calc(100% - (var(--avatar-size) + 5px));
     }
   }
-  &.vertical {
+  &[data-orientation='vertical'] {
     .avatar-text {
       margin-top: 3px;
       max-width: 80px;
@@ -45,12 +45,12 @@
   }
 }
 
-:host.small {
+:host[data-size='small'] {
   .avatar {
     box-shadow: 0 1px 2px 0 $boxShadowColor;
     border-width: 2px;
   }
-  &.clickable .avatar:hover {
+  &[data-clickable='true'] .avatar:hover {
     box-shadow: 0 3px 6px 0 $boxShadowColor;
   }
   .avatar-badge {
@@ -74,13 +74,13 @@
   .slot2-medium {
     @include BodyFont($font-size-body, null, null, $addCssVars: true);
   }
-  &.horizontal {
+  &[data-orientation='horizontal'] {
     .avatar-text {
       margin-left: 8px;
       max-width: calc(100% - (var(--avatar-size) + 8px));
     }
   }
-  &.vertical {
+  &[data-orientation='vertical'] {
     .avatar-text {
       max-width: 100px;
       margin-top: 6px;
@@ -88,12 +88,12 @@
   }
 }
 
-:host.medium {
+:host[data-size='medium'] {
   .avatar {
     box-shadow: 0 2px 4px 0 $boxShadowColor;
     border-width: 3px;
   }
-  &.clickable .avatar:hover {
+  &[data-clickable='true'] .avatar:hover {
     box-shadow: 0 6px 12px 0 $boxShadowColor;
   }
   b-chip {
@@ -118,13 +118,13 @@
   .slot3-small {
     margin-top: 5px;
   }
-  &.horizontal {
+  &[data-orientation='horizontal'] {
     .avatar-text {
       margin-left: 10px;
       max-width: calc(100% - (var(--avatar-size) + 10px));
     }
   }
-  &.vertical {
+  &[data-orientation='vertical'] {
     .avatar-text {
       max-width: 160px;
       margin-top: 14px;
@@ -143,12 +143,12 @@
   }
 }
 
-:host.large {
+:host[data-size='large'] {
   .avatar {
     box-shadow: 0 2px 4px 0 $boxShadowColor;
     border-width: 3px;
   }
-  &.clickable .avatar:hover {
+  &[data-clickable='true'] .avatar:hover {
     box-shadow: 0 6px 12px 0 $boxShadowColor;
   }
   b-chip {
@@ -162,7 +162,7 @@
     @include DisplayFont(
       $font-size-display-1,
       $font-weight-display-1,
-      1,
+      1.12,
       null,
       $addCssVars: true
     );
@@ -179,13 +179,13 @@
   .slot3-small {
     margin-top: 5px;
   }
-  &.horizontal {
+  &[data-orientation='horizontal'] {
     .avatar-text {
       margin-left: 16px;
       max-width: calc(100% - (var(--avatar-size) + 16px));
     }
   }
-  &.vertical {
+  &[data-orientation='vertical'] {
     .avatar-text {
       max-width: 215px;
       margin-top: 3px;

--- a/projects/ui-framework/src/lib/buttons-indicators/avatar/avatar.component.html
+++ b/projects/ui-framework/src/lib/buttons-indicators/avatar/avatar.component.html
@@ -20,14 +20,20 @@
 <div *ngIf="title || subtitle"
      class="avatar-text">
 
-  <h4 [attr.data-max-lines]="orientation === orient.horizontal ? 1 : 2"
-      *ngIf="title"
+  <h4 *ngIf="title"
+      [b-truncate-tooltip]="orientation === orient.horizontal ? 1 : 2"
+      [type]="tooltipType.css"
+      [trustCssVars]="true"
+      [expectChanges]="expectChanges"
       class="slot1-big title">
     {{title}}
   </h4>
 
-  <p [attr.data-max-lines]="orientation === orient.horizontal ? 1 : 2"
-     *ngIf="subtitle && (orientation === orient.horizontal || size > avatarSize.small)"
+  <p *ngIf="subtitle && (orientation === orient.horizontal || size > avatarSize.small)"
+     [b-truncate-tooltip]="orientation === orient.horizontal ? 1 : 2"
+     [type]="tooltipType.css"
+     [trustCssVars]="true"
+     [expectChanges]="expectChanges"
      class="slot2-medium subtitle">
     {{subtitle}}
   </p>

--- a/projects/ui-framework/src/lib/buttons-indicators/avatar/avatar.component.scss
+++ b/projects/ui-framework/src/lib/buttons-indicators/avatar/avatar.component.scss
@@ -90,7 +90,7 @@
 }
 
 :host {
-  &.clickable {
+  &[data-clickable='true'] {
     .avatar {
       cursor: pointer;
 
@@ -104,22 +104,32 @@
     }
   }
 
-  &.disabled {
+  &[data-disabled='true'] {
     @include disabled-state;
   }
 
-  &.horizontal {
+  &[data-orientation='horizontal'] {
     b-chip {
       margin-right: auto;
     }
   }
 
-  &.vertical {
+  &[data-orientation='vertical'] {
     text-align: center;
     flex-direction: column;
 
+    .avatar {
+      margin: 0 auto;
+    }
+
     .avatar-text {
       align-items: center;
+    }
+
+    .slot1-big,
+    .slot2-medium,
+    .slot3-small {
+      max-width: inherit;
     }
 
     [data-max-lines] {

--- a/projects/ui-framework/src/lib/buttons-indicators/avatar/avatar.component.spec.ts
+++ b/projects/ui-framework/src/lib/buttons-indicators/avatar/avatar.component.spec.ts
@@ -75,16 +75,16 @@ describe('AvatarComponent', () => {
     });
   });
 
-  describe('Classes', () => {
-    it('Should put the right classes on component host element', () => {
+  describe('Attributes', () => {
+    it('Should put the right attributes on component host element', () => {
       component.isClickable = true;
       component.ngOnChanges({
         size: new SimpleChange(null, AvatarSize.large, false)
       });
       fixture.detectChanges();
-      expect(componentElem.classList.value).toEqual(
-        'large horizontal clickable'
-      );
+      expect(componentElem.dataset.size).toEqual('large');
+      expect(componentElem.dataset.orientation).toEqual('horizontal');
+      expect(componentElem.dataset.clickable).toEqual('true');
     });
   });
 
@@ -132,10 +132,10 @@ describe('AvatarComponent', () => {
   });
 
   describe('Disabled', () => {
-    it('Should set avatar disabled', () => {
+    it('Should set disabled attribute', () => {
       component.disabled = true;
       fixture.detectChanges();
-      expect(componentElem.classList.value).toContain('disabled');
+      expect(componentElem.dataset.disabled).toEqual('true');
       component.onClick('click');
       expect(component.clicked.emit).not.toHaveBeenCalled();
     });
@@ -202,7 +202,7 @@ describe('AvatarComponent', () => {
     it('Should have vertical orientation', () => {
       component.orientation = AvatarOrientation.vertical;
       fixture.detectChanges();
-      expect(componentElem.classList.value).toContain('vertical');
+      expect(componentElem.dataset.orientation).toEqual('vertical');
       expect(getComputedStyle(componentElem).flexDirection).toEqual('column');
     });
   });

--- a/projects/ui-framework/src/lib/buttons-indicators/avatar/avatar.component.ts
+++ b/projects/ui-framework/src/lib/buttons-indicators/avatar/avatar.component.ts
@@ -21,7 +21,7 @@ import { ChipType } from '../../chips/chips.enum';
 import { Chip } from '../../chips/chips.interface';
 import { BadgeConfig } from './avatar.interface';
 import { getKeyByValue } from '../../services/utils/functional-utils';
-import { TruncateTooltiptype } from '../../services/truncate-tooltip/truncate-tooltip.enum';
+import { TruncateTooltipType } from '../../services/truncate-tooltip/truncate-tooltip.enum';
 
 @Component({
   selector: 'b-avatar',
@@ -44,7 +44,7 @@ export class AvatarComponent implements OnChanges, OnInit, AfterViewInit {
   readonly badgeSize = BadgeSize;
   readonly chipType = ChipType;
   readonly orient = AvatarOrientation;
-  readonly tooltipType = TruncateTooltiptype;
+  readonly tooltipType = TruncateTooltipType;
   public badgeConfig: BadgeConfig;
   public avatarClass: string;
   public avatarStyle: Styles;

--- a/projects/ui-framework/src/lib/buttons-indicators/avatar/avatar.component.ts
+++ b/projects/ui-framework/src/lib/buttons-indicators/avatar/avatar.component.ts
@@ -11,7 +11,8 @@ import {
   OnChanges,
   OnInit,
   ChangeDetectorRef,
-  NgZone
+  NgZone,
+  ChangeDetectionStrategy
 } from '@angular/core';
 import { AvatarSize, AvatarBadge, AvatarOrientation } from './avatar.enum';
 import { AvatarBadges, BadgeSize } from './avatar.consts';
@@ -20,11 +21,13 @@ import { ChipType } from '../../chips/chips.enum';
 import { Chip } from '../../chips/chips.interface';
 import { BadgeConfig } from './avatar.interface';
 import { getKeyByValue } from '../../services/utils/functional-utils';
+import { TruncateTooltiptype } from '../../services/truncate-tooltip/truncate-tooltip.enum';
 
 @Component({
   selector: 'b-avatar',
   templateUrl: './avatar.component.html',
-  styleUrls: ['./avatar.component.scss']
+  styleUrls: ['./avatar.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AvatarComponent implements OnChanges, OnInit, AfterViewInit {
   constructor(
@@ -41,9 +44,11 @@ export class AvatarComponent implements OnChanges, OnInit, AfterViewInit {
   readonly badgeSize = BadgeSize;
   readonly chipType = ChipType;
   readonly orient = AvatarOrientation;
+  readonly tooltipType = TruncateTooltiptype;
   public badgeConfig: BadgeConfig;
   public avatarClass: string;
   public avatarStyle: Styles;
+  public expectChanges = true;
 
   @Input() imageSource: string;
   @Input() backgroundColor?: string;
@@ -53,22 +58,17 @@ export class AvatarComponent implements OnChanges, OnInit, AfterViewInit {
   @Input() chip?: Chip;
   @Input() caption?: string;
   @Input() badge: AvatarBadge | BadgeConfig;
-  @Input() orientation: AvatarOrientation = AvatarOrientation.horizontal;
-  @Input() isClickable = false;
-  @Input() disabled = false;
 
   @Output() clicked?: EventEmitter<void> = new EventEmitter<void>();
 
-  @HostBinding('class')
-  get typeClass(): string {
-    return (
-      getKeyByValue(AvatarSize, this.size) +
-      ' ' +
-      this.orientation +
-      (this.isClickable ? ' clickable' : '') +
-      (this.disabled ? ' disabled' : '')
-    );
+  @HostBinding('attr.data-size') get sizeClass() {
+    return getKeyByValue(AvatarSize, this.size);
   }
+  @HostBinding('attr.data-orientation')
+  @Input()
+  orientation: AvatarOrientation = AvatarOrientation.horizontal;
+  @HostBinding('attr.data-clickable') @Input() isClickable = false;
+  @HostBinding('attr.data-disabled') @Input() disabled = false;
 
   ngOnInit(): void {
     this.setAvatarClass();

--- a/projects/ui-framework/src/lib/buttons-indicators/avatar/avatar.component.ts
+++ b/projects/ui-framework/src/lib/buttons-indicators/avatar/avatar.component.ts
@@ -48,7 +48,6 @@ export class AvatarComponent implements OnChanges, OnInit, AfterViewInit {
   public badgeConfig: BadgeConfig;
   public avatarClass: string;
   public avatarStyle: Styles;
-  public expectChanges = true;
 
   @Input() imageSource: string;
   @Input() backgroundColor?: string;
@@ -58,6 +57,7 @@ export class AvatarComponent implements OnChanges, OnInit, AfterViewInit {
   @Input() chip?: Chip;
   @Input() caption?: string;
   @Input() badge: AvatarBadge | BadgeConfig;
+  @Input() expectChanges = false;
 
   @Output() clicked?: EventEmitter<void> = new EventEmitter<void>();
 

--- a/projects/ui-framework/src/lib/services/component-renderer/component-renderer.component.spec.ts
+++ b/projects/ui-framework/src/lib/services/component-renderer/component-renderer.component.spec.ts
@@ -70,7 +70,7 @@ describe('ComponentRendererComponent', () => {
         avatarComponent = fixture.debugElement.query(By.css('.slot-1 b-avatar'))
           .componentInstance;
         avatarNativeElement = fixture.debugElement.query(
-          By.css('b-avatar.clickable .avatar')
+          By.css('b-avatar[data-clickable="true"] .avatar')
         ).nativeElement;
         textElement = fixture.debugElement.query(By.css('.slot-2'))
           .nativeElement;

--- a/projects/ui-framework/src/lib/services/truncate-tooltip/truncate-tooltip.component.spec.ts
+++ b/projects/ui-framework/src/lib/services/truncate-tooltip/truncate-tooltip.component.spec.ts
@@ -11,7 +11,7 @@ import { UtilsService } from '../utils/utils.service';
 import { UtilsModule } from '../utils/utils.module';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TruncateTooltipModule } from './truncate-tooltip.module';
-import { TruncateTooltiptype } from './truncate-tooltip.enum';
+import { TruncateTooltipType } from './truncate-tooltip.enum';
 
 @Component({
   template: `
@@ -95,12 +95,12 @@ describe('TruncateTooltipComponent', () => {
           By.css('b-truncate-tooltip:not(.test1)')
         ).componentInstance;
 
-        bttComp1.type = TruncateTooltiptype.material;
+        bttComp1.type = TruncateTooltipType.material;
         bttComp1.expectChanges = true;
         bttComp1.trustCssVars = false;
         bttComp1.delay = 0;
         bttComp1.lazyness = 0;
-        bttComp2.type = TruncateTooltiptype.material;
+        bttComp2.type = TruncateTooltipType.material;
         bttComp2.expectChanges = true;
         bttComp2.trustCssVars = false;
         bttComp2.delay = 0;

--- a/projects/ui-framework/src/lib/services/truncate-tooltip/truncate-tooltip.component.ts
+++ b/projects/ui-framework/src/lib/services/truncate-tooltip/truncate-tooltip.component.ts
@@ -9,11 +9,13 @@ import {
   DoCheck,
   NgZone,
   OnInit,
-  ChangeDetectorRef,
-  ChangeDetectionStrategy
+  ChangeDetectorRef
 } from '@angular/core';
 import { DOMhelpers, TextProps } from '../utils/dom-helpers.service';
-import { TruncateTooltiptype } from './truncate-tooltip.enum';
+import {
+  TruncateTooltipType,
+  TruncateTooltipPosition
+} from './truncate-tooltip.enum';
 import { debounce } from 'lodash';
 
 @Component({
@@ -24,13 +26,14 @@ import { debounce } from 'lodash';
       class="tooltip-trigger"
       [matTooltip]="tooltipText"
       [matTooltipShowDelay]="delay"
-      matTooltipPosition="above"
+      [matTooltipPosition]="position"
       matTooltipClass="b-truncate-tooltip"
     ></i>
     <i
       *ngIf="type === types.css && tooltipEnabled"
       class="tooltip-trigger"
       [attr.data-tooltip]="tooltipText"
+      [attr.data-tooltip-position]="position"
     ></i>
     <div
       #textContainer
@@ -71,7 +74,8 @@ export class TruncateTooltipComponent
   @Input() lazyness = 200;
   @Input() expectChanges = false;
   @Input() trustCssVars = false;
-  @Input() type: TruncateTooltiptype = TruncateTooltiptype.auto;
+  @Input() type: TruncateTooltipType = TruncateTooltipType.auto;
+  @Input() position = TruncateTooltipPosition.above;
 
   private textElementTextProps: TextProps;
   private maxLinesDefault = 1;
@@ -82,10 +86,10 @@ export class TruncateTooltipComponent
   public tooltipEnabled = false;
   public tooltipAllowed = false;
   public initialized = this.trustCssVars;
-  readonly types = TruncateTooltiptype;
+  readonly types = TruncateTooltipType;
 
   ngOnInit(): void {
-    if (this.lazyness !== 0 && this.type !== TruncateTooltiptype.css) {
+    if (this.lazyness !== 0 && this.type !== TruncateTooltipType.css) {
       this.textContainer.nativeElement.addEventListener(
         'mouseenter',
         this.startHoverTimer
@@ -112,7 +116,7 @@ export class TruncateTooltipComponent
         this.checkTooltipNecessity();
 
         this.initialized = true;
-        if (this.type === TruncateTooltiptype.css || this.lazyness === 0) {
+        if (this.type === TruncateTooltipType.css || this.lazyness === 0) {
           this.tooltipAllowed = true;
           this.stopHoverTimer();
           this.removeMouseListeners();
@@ -181,11 +185,11 @@ export class TruncateTooltipComponent
   }
 
   private checkTooltipNecessity(): void {
-    if (this.type === TruncateTooltiptype.auto) {
+    if (this.type === TruncateTooltipType.auto) {
       this.type =
         this.tooltipText.length > 130
-          ? TruncateTooltiptype.material
-          : TruncateTooltiptype.css;
+          ? TruncateTooltipType.material
+          : TruncateTooltipType.css;
     }
 
     const compareHeight = this.trustCssVars

--- a/projects/ui-framework/src/lib/services/truncate-tooltip/truncate-tooltip.enum.ts
+++ b/projects/ui-framework/src/lib/services/truncate-tooltip/truncate-tooltip.enum.ts
@@ -1,5 +1,10 @@
-export enum TruncateTooltiptype {
+export enum TruncateTooltipType {
   auto = 'auto',
   material = 'material',
   css = 'css'
+}
+
+export enum TruncateTooltipPosition {
+  above = 'above',
+  below = 'below'
 }

--- a/projects/ui-framework/src/lib/services/truncate-tooltip/truncate-tooltip.stories.ts
+++ b/projects/ui-framework/src/lib/services/truncate-tooltip/truncate-tooltip.stories.ts
@@ -97,6 +97,10 @@ const note = `
   maxLines | number | maximum lines. the overflowing text will be truncated and tooltip with full text will be shown. to disable truncation, set to 0 or null. | 1 (optional)
   type | TruncateTooltipType | Use Material tooltip or CSS tooltip. Defaut 'auto' type will use Material for text longer than 130 chars, otherwise CSS | auto
   position | TruncateTooltipPosition | above or below | above
+  trustCssVars | boolean | performance can be optimised, if --line-height and --font-size CSS variables exist on the element | false
+  expectChanges | boolean | if text inside truncate-tooltip component will be changing, set to true | false
+  delay | number | time in ms before tooltip shows | 300
+  lazyness | number | if type is Material, it will be initialized lazyly after this many ms of hover | 200
 
    --------
 
@@ -109,6 +113,7 @@ const note = `
   Name | Type | Description | Default value
   --- | --- | --- | ---
   b-truncate-tooltip (or maxLines) | number | maximum lines | 1 (optional)
+  other properties are the same as in example 1
 
  --------
 
@@ -121,6 +126,7 @@ const note = `
   Name | Type | Description | Default value
   --- | --- | --- | ---
   bTruncateTooltip | number | maximum lines  | 1 (optional)
+  other properties are not supported
 
   --------
 

--- a/projects/ui-framework/src/lib/services/truncate-tooltip/truncate-tooltip.stories.ts
+++ b/projects/ui-framework/src/lib/services/truncate-tooltip/truncate-tooltip.stories.ts
@@ -12,7 +12,10 @@ import { StoryBookLayoutModule } from '../../story-book-layout/story-book-layout
 import { TypographyModule } from '../../typography/typography.module';
 import { TruncateTooltipModule } from './truncate-tooltip.module';
 import { UtilComponentsModule } from '../util-components/utilComponents.module';
-import { TruncateTooltiptype } from './truncate-tooltip.enum';
+import {
+  TruncateTooltipType,
+  TruncateTooltipPosition
+} from './truncate-tooltip.enum';
 
 const story = storiesOf(ComponentGroupType.Services, module).addDecorator(
   withKnobs
@@ -25,7 +28,9 @@ const template1 = `
   </b-big-body>
 `;
 const template2 = `
-  <b-truncate-tooltip [maxLines]="maxLines" [type]="type" class="employee-title">
+  <b-truncate-tooltip [maxLines]="maxLines"
+                      [type]="type" class="employee-title"
+                      [position]="position">
     <b-display-3>
       <span>
         <!-- this html comment should not be displayed -->
@@ -38,14 +43,17 @@ const template2 = `
   </b-truncate-tooltip>
 `;
 const template3 = `
-  <p b-truncate-tooltip="3" [type]="type" class="employee-title">
+  <p b-truncate-tooltip="3"
+     [type]="type"
+     [position]="position" class="employee-title">
     <span>{{ text1 }}</span>
     <span>{{ text2 }}</span>
   </p>
 `;
 
 const template4 = `
-  <div b-truncate-tooltip="2" [type]="'css'">
+  <div b-truncate-tooltip="2" [type]="'css'"
+                              [position]="position">
     <h3>
       This is a pure CSS tooltip! Looks and feels the same as matTooltip-based ones.
       Can't be used inside overflow hidden containers.
@@ -87,7 +95,8 @@ const note = `
   Name | Type | Description | Default value
   --- | --- | --- | ---
   maxLines | number | maximum lines. the overflowing text will be truncated and tooltip with full text will be shown. to disable truncation, set to 0 or null. | 1 (optional)
-  type | TruncateTooltiptype | Use Material tooltip or CSS tooltip. Defaut 'auto' type will use Material for text longer than 130 chars, otherwise CSS | auto
+  type | TruncateTooltipType | Use Material tooltip or CSS tooltip. Defaut 'auto' type will use Material for text longer than 130 chars, otherwise CSS | auto
+  position | TruncateTooltipPosition | above or below | above
 
    --------
 
@@ -140,8 +149,13 @@ story.add(
         maxLines: number('bTruncateTooltip/maxLines', 2),
         type: select(
           'type',
-          Object.values(TruncateTooltiptype),
-          TruncateTooltiptype.auto
+          Object.values(TruncateTooltipType),
+          TruncateTooltipType.auto
+        ),
+        position: select(
+          'position',
+          Object.values(TruncateTooltipPosition),
+          TruncateTooltipPosition.above
         ),
         text1: text(
           'text1',

--- a/projects/ui-framework/src/lib/style/tooltip.scss
+++ b/projects/ui-framework/src/lib/style/tooltip.scss
@@ -79,6 +79,20 @@ $toolti-offset: 10px;
     transform: translateY(0) scale(1);
   }
 }
+@keyframes tooltip-arrow-apprnc-below {
+  0% {
+    opacity: 0;
+    transform: translateY(12px) scale(0);
+  }
+  50% {
+    opacity: 0.65;
+    transform: translateY(0) scale(0.99);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
 
 [data-tooltip] {
   &:after {
@@ -86,22 +100,48 @@ $toolti-offset: 10px;
     content: attr(data-tooltip);
     @extend %tooltip-body;
     position: absolute;
-    bottom: 100%;
     left: 50%;
     transform: translateX(-50%);
     z-index: 10;
     white-space: normal;
-    transform-origin: center bottom;
     @include animate(tooltip-apprnc, 0.1s, 0.3s);
     animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
   }
 
   &:before {
     @extend %tooltip-arrow-common;
-    @include arrow-down($tooltip-arrow-size, $tooltip-color);
-    bottom: calc(100% + #{$toolti-offset - $tooltip-arrow-size/2});
-    transform-origin: center bottom;
-    @include animate(tooltip-arrow-apprnc, 0.1s, 0.3s);
+  }
+
+  // position above (default)
+  &,
+  &[data-tooltip-position='above'] {
+    &:after {
+      bottom: 100%;
+      transform-origin: center bottom;
+    }
+    &:before {
+      @include arrow-down($tooltip-arrow-size, $tooltip-color);
+      bottom: calc(100% + #{$toolti-offset - $tooltip-arrow-size/2});
+      transform-origin: center bottom;
+      @include animate(tooltip-arrow-apprnc, 0.1s, 0.3s);
+    }
+  }
+
+  // position below
+  &[data-tooltip-position='below'] {
+    &:after {
+      bottom: auto;
+      top: 100%;
+      transform-origin: center top;
+    }
+    &:before {
+      border-top: 0;
+      border-bottom: ($tooltip-arrow-size/2) solid $tooltip-color;
+      bottom: auto;
+      top: calc(100% + #{$toolti-offset - $tooltip-arrow-size/2});
+      transform-origin: center top;
+      animation-name: tooltip-arrow-apprnc-below;
+    }
   }
 
   &:not(:hover),

--- a/projects/ui-framework/src/lib/style/typography.scss
+++ b/projects/ui-framework/src/lib/style/typography.scss
@@ -53,7 +53,6 @@ $font-size-subheading: $font-size-body;
   color: $grey-700;
   @include FontDefault($style, $weight, $size, $lineHeight, $addCssVars);
   font-family: $font-family;
-  display: block;
   text-transform: $transform;
 }
 
@@ -66,7 +65,6 @@ $font-size-subheading: $font-size-body;
 ) {
   @include FontDefault($style, $weight, $size, $lineHeight, $addCssVars);
   font-family: var(--heading-font-family);
-  display: block;
 }
 
 @mixin BodyFont(

--- a/projects/ui-framework/src/lib/typography/display-1/display-1.component.scss
+++ b/projects/ui-framework/src/lib/typography/display-1/display-1.component.scss
@@ -1,4 +1,5 @@
 @import '../../style/typography.scss';
 :host {
+  display: block;
   @include DisplayFont($font-size-display-1, $font-weight-display-1);
 }

--- a/projects/ui-framework/src/lib/typography/display-2/display-2.component.scss
+++ b/projects/ui-framework/src/lib/typography/display-2/display-2.component.scss
@@ -1,4 +1,5 @@
 @import '../../style/typography.scss';
 :host {
+  display: block;
   @include DisplayFont(28px, 900);
 }

--- a/projects/ui-framework/src/lib/typography/display-3/display-3.component.scss
+++ b/projects/ui-framework/src/lib/typography/display-3/display-3.component.scss
@@ -1,4 +1,5 @@
 @import '../../style/typography.scss';
 :host {
+  display: block;
   @include DisplayFont(22px, 600);
 }

--- a/projects/ui-framework/src/lib/typography/display-4/display-4.component.scss
+++ b/projects/ui-framework/src/lib/typography/display-4/display-4.component.scss
@@ -1,4 +1,5 @@
 @import '../../style/typography.scss';
 :host {
+  display: block;
   @include DisplayFont(18px, 500);
 }

--- a/projects/ui-framework/src/lib/typography/heading/heading.component.scss
+++ b/projects/ui-framework/src/lib/typography/heading/heading.component.scss
@@ -1,4 +1,5 @@
 @import '../../style/typography.scss';
 :host {
+  display: block;
   @include HeadingFont($font-size-heading);
 }

--- a/projects/ui-framework/src/lib/typography/subheading/subheading.component.scss
+++ b/projects/ui-framework/src/lib/typography/subheading/subheading.component.scss
@@ -1,4 +1,5 @@
 @import '../../style/typography.scss';
 :host {
+  display: block;
   @include HeadingFont($font-size-subheading);
 }

--- a/projects/ui-framework/src/public_api.ts
+++ b/projects/ui-framework/src/public_api.ts
@@ -370,6 +370,7 @@ export { RenderedComponent } from './lib/services/component-renderer/component-r
 export { TruncateTooltipModule} from './lib/services/truncate-tooltip/truncate-tooltip.module';
 export { TruncateTooltipComponent} from './lib/services/truncate-tooltip/truncate-tooltip.component';
 export { TruncateTooltipDirective } from './lib/services/truncate-tooltip/truncate-tooltip.directive';
+export { TruncateTooltipType, TruncateTooltipPosition } from './lib/services/truncate-tooltip/truncate-tooltip.enum';
 
 
 /*


### PR DESCRIPTION
- enabled truncate-tooltip in avatar
- removed 'display: block' from typography mixins
- added position-below option for CSS tooltip
- added 'position' input to truncate-tooltip
