### PR TITLE
move showcase to the left

### DIFF
--- a/projects/ui-framework/src/lib/buttons-indicators/employees-showcase/employees-showcase.component.scss
+++ b/projects/ui-framework/src/lib/buttons-indicators/employees-showcase/employees-showcase.component.scss
@@ -4,7 +4,6 @@
   position: relative;
   width: 100%;
   display: flex;
-  justify-content: center;
 
   ::ng-deep .avatar {
     transition: background-image 0.5s ease-in-out !important;


### PR DESCRIPTION
I talked with Shmulik and by default the ees should appear to the left and not in the center of the component