### PR TITLE
Danny/chain select structural directive

### DIFF
--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.html
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.html
@@ -2,8 +2,7 @@
 
   <div class="chain-link-row">
 
-    <b-component-renderer [render]="chainLink.selectComponentConfig">
-    </b-component-renderer>
+    <ng-container *ngTemplateOutlet="contentChild.tpl"></ng-container>
 
     <b-square-button class="delete-button"
                      *ngIf="chainLinkList.length > 1"

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.html
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.html
@@ -6,7 +6,7 @@
     </ng-container>
 
     <b-square-button class="delete-button"
-                     *ngIf="chainLinkList.length > 1"
+                     *ngIf="selectedItemList.length > 1"
                      [type]="buttonType.tertiary"
                      [size]="buttonSize.large"
                      [icon]="icons.delete"

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.html
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.html
@@ -2,7 +2,7 @@
 
   <div class="chain-link-row">
 
-    <ng-container *ngTemplateOutlet="contentChild.tpl; context: { selected: selected, selectChange: handleChange.bind(this), index: i }">
+    <ng-container *ngTemplateOutlet="contentChild?.tpl; context: { selected: selected, selectChange: handleChange.bind(this), index: i }">
     </ng-container>
 
     <b-square-button class="delete-button"

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.html
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.html
@@ -1,8 +1,9 @@
-<ng-container *ngFor="let chainLink of chainLinkList; index as i;">
+<ng-container *ngFor="let selected of selectedItemList; index as i;">
 
   <div class="chain-link-row">
 
-    <ng-container *ngTemplateOutlet="contentChild.tpl"></ng-container>
+    <ng-container *ngTemplateOutlet="contentChild.tpl; context: { selected: selected, $implicit: selected }">
+    </ng-container>
 
     <b-square-button class="delete-button"
                      *ngIf="chainLinkList.length > 1"

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.html
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.html
@@ -2,7 +2,7 @@
 
   <div class="chain-link-row">
 
-    <ng-container *ngTemplateOutlet="contentChild.tpl; context: { selected: selected, $implicit: selected }">
+    <ng-container *ngTemplateOutlet="contentChild.tpl; context: { selected: selected, selectChange: handleChange.bind(this), index: i }">
     </ng-container>
 
     <b-square-button class="delete-button"

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.html
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.html
@@ -1,12 +1,12 @@
-<ng-container *ngFor="let selected of selectedItemList; index as i;">
+<ng-container *ngFor="let chainLink of chainLinkList; index as i;">
 
   <div class="chain-link-row">
 
-    <ng-container *ngTemplateOutlet="contentChild?.tpl; context: { selected: selected, selectChange: handleChange.bind(this), index: i }">
+    <ng-container *ngTemplateOutlet="contentChild?.tpl; context: { selected: chainLink, selectChange: handleChange.bind(this), index: i }">
     </ng-container>
 
     <b-square-button class="delete-button"
-                     *ngIf="selectedItemList.length > 1"
+                     *ngIf="chainLinkList.length > 1"
                      [type]="buttonType.tertiary"
                      [size]="buttonSize.large"
                      [icon]="icons.delete"

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.scss
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.scss
@@ -13,10 +13,6 @@
     }
   }
 
-  b-component-renderer {
-    display: block;
-  }
-
   .delete-button {
     display: none;
     position: absolute;

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.scss
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.scss
@@ -22,7 +22,7 @@
 }
 
 .then {
-  margin: 8px 0 8px 16px;
+  margin: times8(1) 0 times8(1) times8(2);
 
   b-icon {
     transform: rotate(90deg);

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.spec.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.spec.ts
@@ -1,74 +1,27 @@
-import { Component, EventEmitter, Input, NgModule, Output, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ChainSelectComponent } from './chain-select.component';
 import { IconsModule } from '../../../icons/icons.module';
-import { ComponentRendererModule } from '../../../services/component-renderer/component-renderer.module';
 import { By } from '@angular/platform-browser';
 import { ButtonsModule } from '../../../buttons/buttons.module';
-import { ListChange } from '../list-change/list-change';
-import createSpy = jasmine.createSpy;
-import any = jasmine.any;
+import { ChainSelectDirective } from './chain-select.directive';
 
 describe('EmployeeChainSelectComponent', () => {
   let component: ChainSelectComponent;
   let fixture: ComponentFixture<ChainSelectComponent>;
   let TestComponent;
-  let emptyChainLink;
 
   beforeEach(async(() => {
-    @Component({
-      selector: 'b-test-select',
-      template: '<select (click)="change($event)"></select>'
-    })
-    class TestSelectComponent implements OnInit {
-      @Input() filterFn?: Function;
-      @Output() selectChange: EventEmitter<any> = new EventEmitter<any>();
-
-      ngOnInit() {
-        if (this.filterFn) {
-          this.filterFn();
-        }
-      }
-
-      public change($event) {
-        this.selectChange.emit($event);
-      }
-    }
-
-    TestComponent = TestSelectComponent;
-
-    @NgModule({
-      imports: [CommonModule],
-      exports: [TestSelectComponent],
-      declarations: [TestSelectComponent],
-      entryComponents: [TestSelectComponent]
-    })
-    class TestSelectModule { }
-
-    emptyChainLink = {
-      selectComponentConfig: {
-        component: TestComponent,
-        attributes: {
-          filterFn: any(Function),
-        },
-        handlers: {
-          'selectChange': any(Function)
-        }
-      }
-    };
-
     TestBed.configureTestingModule({
       declarations: [
-        ChainSelectComponent
+        ChainSelectComponent,
+        ChainSelectDirective,
       ],
       imports: [
         CommonModule,
         IconsModule,
         ButtonsModule,
-        ComponentRendererModule,
-        TestSelectModule
-      ]
+      ],
     })
       .compileComponents();
   }));
@@ -76,82 +29,16 @@ describe('EmployeeChainSelectComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ChainSelectComponent);
     component = fixture.componentInstance;
-    component.selectComponent = TestComponent;
-    component.selectComponentConfig = {
-      selectedIdKey: 'selectedId',
-      outputKey: 'selectChange',
-      selectedIds: [],
-      filterFn: createSpy('filterFn'),
-    };
     fixture.detectChanges();
-  });
-
-  describe('onInit', () => {
-    it('Should set one empty chain link if none are selected', () => {
-      expect(component.chainLinkList).toEqual([emptyChainLink]);
-    });
-
-    it('Should set chain links according to selected ids', () => {
-      component.selectComponentConfig.selectedIds = ['123'];
-      component.ngOnInit();
-      expect(component.chainLinkList).toEqual([{
-        selectComponentConfig: {
-          component: TestComponent,
-          attributes: {
-            'selectedId': '123',
-            filterFn: any(Function),
-          },
-          handlers: {
-            'selectChange': any(Function)
-          }
-        }
-      }]);
-    });
-
-    it('Should show one select by default', () => {
-      const selectElements = fixture.debugElement.queryAll(By.css('select'));
-      expect(selectElements.length).toBe(1);
-    });
-
-    it('Should create select element for each selected ID', () => {
-      component.selectComponentConfig.selectedIds = ['123'];
-      component.ngOnInit();
-      fixture.detectChanges();
-      const selectElements = fixture.debugElement.queryAll(By.css('select'));
-      expect(selectElements.length).toBe(1);
-    });
-
-    it('Should set empty state', () => {
-      expect(component.state).toEqual([null]);
-    });
-
-    it('Should set state from selected IDs', () => {
-      component.selectComponentConfig.selectedIds = ['123'];
-      component.ngOnInit();
-      expect(component.state[0]).toBeNull();
-    });
-
-    it('Should set a filter function on the select component', () => {
-      expect(component.selectComponentConfig.filterFn).toHaveBeenCalled();
-    });
   });
 
   describe('addChainLink', () => {
     it('Should add chain link to the list', () => {
       component.addChainLink();
-      expect(component.chainLinkList).toEqual([emptyChainLink, emptyChainLink]);
-    });
-
-    it('Should bind callback to the newly created link', () => {
-      spyOn(component.selectChange, 'emit');
-      component.addChainLink();
+      expect(component.selectedItemList).toEqual([null, null]);
       fixture.detectChanges();
-      const selectElement = fixture.debugElement.queryAll(By.css('select'))[1];
-      selectElement.triggerEventHandler('click', new ListChange([]));
-      expect(component.selectChange.emit).toHaveBeenCalledWith([
-        null,
-        any(ListChange)
-      ]);
+      const rows = fixture.debugElement.queryAll(By.css('.chain-link-row'));
+      expect(rows.length).toEqual(2);
     });
   });
 
@@ -161,21 +48,23 @@ describe('EmployeeChainSelectComponent', () => {
       fixture.detectChanges();
       component.removeChainLink(1);
       fixture.detectChanges();
-      const selectElements = fixture.debugElement.queryAll(By.css('select'));
-      expect(selectElements.length).toEqual(1);
-    });
-
-    it('Should modify state', () => {
-      component.addChainLink();
-      component.removeChainLink(1);
-      expect(component.state[1]).toBeUndefined();
+      const rows = fixture.debugElement.queryAll(By.css('.chain-link-row'));
+      expect(rows.length).toEqual(1);
     });
 
     it('Should emit change', () => {
       spyOn(component.selectChange, 'emit');
       component.addChainLink();
       component.removeChainLink(1);
-      expect(component.selectChange.emit).toHaveBeenCalledWith(component.state);
+      expect(component.selectChange.emit).toHaveBeenCalledWith({ event: 'delete', index: 1 });
     });
+  });
+
+  describe('handleChange', () => {
+    it('Should emit change', () => {
+      spyOn(component.selectChange, 'emit');
+      component.handleChange({}, 0);
+      expect(component.selectChange.emit).toHaveBeenCalledWith({ event: {}, index: 0 });
+    })
   });
 });

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.spec.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.spec.ts
@@ -9,7 +9,6 @@ import { ChainSelectDirective } from './chain-select.directive';
 describe('EmployeeChainSelectComponent', () => {
   let component: ChainSelectComponent;
   let fixture: ComponentFixture<ChainSelectComponent>;
-  let TestComponent;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -35,7 +34,7 @@ describe('EmployeeChainSelectComponent', () => {
   describe('addChainLink', () => {
     it('Should add chain link to the list', () => {
       component.addChainLink();
-      expect(component.selectedItemList).toEqual([null, null]);
+      expect(component.chainLinkList).toEqual([null, null]);
       fixture.detectChanges();
       const rows = fixture.debugElement.queryAll(By.css('.chain-link-row'));
       expect(rows.length).toEqual(2);

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.ts
@@ -13,6 +13,7 @@ import { ChainSelectDirective } from './chain-select.directive';
 })
 export class ChainSelectComponent implements OnInit {
   @Input() actionLabel: string;
+  @Input() selectedItemList: [];
   @Output() selectChange: EventEmitter<ListChange[]> =
     new EventEmitter<ListChange[]>();
 
@@ -23,7 +24,7 @@ export class ChainSelectComponent implements OnInit {
   public chainLinkList: ChainLink[];
   public state: ListChange[];
 
-  @ContentChild(ChainSelectDirective, { static: false }) contentChild !: ChainSelectDirective;
+  @ContentChild(ChainSelectDirective, { static: true }) contentChild !: ChainSelectDirective;
 
   constructor() {}
 

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.ts
@@ -1,52 +1,43 @@
 import { Component, EventEmitter, Input, OnInit, Output, Type, ContentChild } from '@angular/core';
-import { isEmpty, clone } from 'lodash';
-import { ChainLink, SelectComponentConfig } from './chain-select.interface';
 import { Icons, IconSize } from '../../../icons/icons.enum';
 import { ButtonSize, ButtonType } from '../../../buttons/buttons.enum';
-import { ListChange } from '../list-change/list-change';
 import { ChainSelectDirective } from './chain-select.directive';
+import { ChainSelectEvent } from './chain-select.interface';
+import { ChainSelectEventEnum } from './chain-select.enum';
 
 @Component({
   selector: 'b-chain-select',
   templateUrl: './chain-select.component.html',
   styleUrls: ['./chain-select.component.scss']
 })
-export class ChainSelectComponent implements OnInit {
+export class ChainSelectComponent {
   @Input() actionLabel: string;
-  @Input() selectedItemList: [];
-  @Output() selectChange: EventEmitter<{ $event: any, index: number }> =
-    new EventEmitter<{ $event: any, index: number }>();
+  @Input() selectedItemList: any[] = [];
+  @Output() selectChange: EventEmitter<ChainSelectEvent> =
+    new EventEmitter<ChainSelectEvent>();
 
   readonly icons = Icons;
   readonly iconSize = IconSize;
   readonly buttonType = ButtonType;
   readonly buttonSize = ButtonSize;
-  public chainLinkList: ChainLink[];
-  public state: ListChange[];
 
   @ContentChild(ChainSelectDirective, { static: true }) contentChild !: ChainSelectDirective;
 
   constructor() {}
 
-  ngOnInit() {
-     this.chainLinkList = [];
-  }
-
   public addChainLink() {
-    this.chainLinkList.push(this.createEmptyChainLink(this.chainLinkList.length));
+    this.selectedItemList.push(null);
   }
 
   public removeChainLink(index: number) {
-    this.chainLinkList.splice(index, 1);
-    this.state.splice(index, 1);
-    //this.selectChange.emit(this.state);
-  }
-
-  private createEmptyChainLink(index: number): ChainLink {
-    return null;
+    this.selectedItemList.splice(index, 1);
+    this.selectChange.emit({
+      index,
+      event: ChainSelectEventEnum.delete,
+    });
   }
 
   public handleChange($event, index) {
-    this.selectChange.emit({ $event, index });
+    this.selectChange.emit({ index, event: $event });
   }
 }

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Input, OnInit, Output, Type, ContentChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, ContentChild } from '@angular/core';
+import { cloneDeep } from 'lodash';
 import { Icons, IconSize } from '../../../icons/icons.enum';
 import { ButtonSize, ButtonType } from '../../../buttons/buttons.enum';
 import { ChainSelectDirective } from './chain-select.directive';
@@ -10,11 +11,13 @@ import { ChainSelectEventEnum } from './chain-select.enum';
   templateUrl: './chain-select.component.html',
   styleUrls: ['./chain-select.component.scss']
 })
-export class ChainSelectComponent {
+export class ChainSelectComponent implements OnInit {
   @Input() actionLabel: string;
   @Input() selectedItemList: any[] = [null];
   @Output() selectChange: EventEmitter<ChainSelectEvent> =
     new EventEmitter<ChainSelectEvent>();
+
+  public chainLinkList: any[];
 
   readonly icons = Icons;
   readonly iconSize = IconSize;
@@ -23,12 +26,16 @@ export class ChainSelectComponent {
 
   @ContentChild(ChainSelectDirective, { static: true }) contentChild !: ChainSelectDirective;
 
+  ngOnInit() {
+    this.chainLinkList = cloneDeep(this.selectedItemList);
+  }
+
   public addChainLink() {
-    this.selectedItemList.push(null);
+    this.chainLinkList.push(null);
   }
 
   public removeChainLink(index: number) {
-    this.selectedItemList.splice(index, 1);
+    this.chainLinkList.splice(index, 1);
     this.selectChange.emit({
       index,
       event: ChainSelectEventEnum.delete,

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.ts
@@ -1,9 +1,10 @@
-import { Component, EventEmitter, Input, OnInit, Output, Type } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, Type, ContentChild } from '@angular/core';
 import { isEmpty, clone } from 'lodash';
 import { ChainLink, SelectComponentConfig } from './chain-select.interface';
 import { Icons, IconSize } from '../../../icons/icons.enum';
 import { ButtonSize, ButtonType } from '../../../buttons/buttons.enum';
 import { ListChange } from '../list-change/list-change';
+import { ChainSelectDirective } from './chain-select.directive';
 
 @Component({
   selector: 'b-chain-select',
@@ -12,8 +13,6 @@ import { ListChange } from '../list-change/list-change';
 })
 export class ChainSelectComponent implements OnInit {
   @Input() actionLabel: string;
-  @Input() selectComponent: Type<any>;
-  @Input() selectComponentConfig: SelectComponentConfig;
   @Output() selectChange: EventEmitter<ListChange[]> =
     new EventEmitter<ListChange[]>();
 
@@ -24,27 +23,12 @@ export class ChainSelectComponent implements OnInit {
   public chainLinkList: ChainLink[];
   public state: ListChange[];
 
+  @ContentChild(ChainSelectDirective, { static: false }) contentChild !: ChainSelectDirective;
+
   constructor() {}
 
   ngOnInit() {
-    if (isEmpty(this.selectComponentConfig.selectedIds) || !this.selectComponentConfig.selectedIdKey) {
-      this.chainLinkList = [this.createEmptyChainLink(0)];
-      this.state = [null];
-    } else {
-      this.chainLinkList = this.selectComponentConfig.selectedIds.map((optionId, index) => ({
-        selectComponentConfig: {
-          component: this.selectComponent,
-          attributes: {
-            [this.selectComponentConfig.selectedIdKey]: optionId,
-            ...this.selectComponentConfig.filterFn && { filterFn: this.selectComponentConfig.filterFn },
-          },
-          handlers: {
-            [this.selectComponentConfig.outputKey]: $event => this.handleChange($event, index)
-          }
-        }
-      }));
-      this.state = this.selectComponentConfig.selectedIds.map(() => null);
-    }
+     this.chainLinkList = [];
   }
 
   public addChainLink() {
@@ -58,17 +42,7 @@ export class ChainSelectComponent implements OnInit {
   }
 
   private createEmptyChainLink(index: number): ChainLink {
-    return {
-      selectComponentConfig: {
-        component: this.selectComponent,
-        attributes: {
-          ...this.selectComponentConfig.filterFn && { filterFn: this.selectComponentConfig.filterFn },
-        },
-        handlers: {
-          [this.selectComponentConfig.outputKey]: $event => this.handleChange($event, index)
-        }
-      }
-    };
+    return null;
   }
 
   private handleChange($event, index) {

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.ts
@@ -14,8 +14,8 @@ import { ChainSelectDirective } from './chain-select.directive';
 export class ChainSelectComponent implements OnInit {
   @Input() actionLabel: string;
   @Input() selectedItemList: [];
-  @Output() selectChange: EventEmitter<ListChange[]> =
-    new EventEmitter<ListChange[]>();
+  @Output() selectChange: EventEmitter<{ $event: any, index: number }> =
+    new EventEmitter<{ $event: any, index: number }>();
 
   readonly icons = Icons;
   readonly iconSize = IconSize;
@@ -39,15 +39,14 @@ export class ChainSelectComponent implements OnInit {
   public removeChainLink(index: number) {
     this.chainLinkList.splice(index, 1);
     this.state.splice(index, 1);
-    this.selectChange.emit(this.state);
+    //this.selectChange.emit(this.state);
   }
 
   private createEmptyChainLink(index: number): ChainLink {
     return null;
   }
 
-  private handleChange($event, index) {
-    this.state.splice(index, 1, $event);
-    this.selectChange.emit(this.state);
+  public handleChange($event, index) {
+    this.selectChange.emit({ $event, index });
   }
 }

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.ts
@@ -12,7 +12,7 @@ import { ChainSelectEventEnum } from './chain-select.enum';
 })
 export class ChainSelectComponent {
   @Input() actionLabel: string;
-  @Input() selectedItemList: any[] = [];
+  @Input() selectedItemList: any[] = [null];
   @Output() selectChange: EventEmitter<ChainSelectEvent> =
     new EventEmitter<ChainSelectEvent>();
 
@@ -22,8 +22,6 @@ export class ChainSelectComponent {
   readonly buttonSize = ButtonSize;
 
   @ContentChild(ChainSelectDirective, { static: true }) contentChild !: ChainSelectDirective;
-
-  constructor() {}
 
   public addChainLink() {
     this.selectedItemList.push(null);

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.directive.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.directive.ts
@@ -4,7 +4,5 @@ import { Directive, TemplateRef } from '@angular/core';
   selector: '[bChainSelect]'
 })
 export class ChainSelectDirective {
-
-  constructor(private tpl : TemplateRef<any>) { }
-
+  constructor(private tpl: TemplateRef<any>) { }
 }

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.directive.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.directive.ts
@@ -1,0 +1,10 @@
+import { Directive, TemplateRef } from '@angular/core';
+
+@Directive({
+  selector: '[bChainSelect]'
+})
+export class ChainSelectDirective {
+
+  constructor(private tpl : TemplateRef<any>) { }
+
+}

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.directive.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.directive.ts
@@ -4,5 +4,5 @@ import { Directive, TemplateRef } from '@angular/core';
   selector: '[bChainSelect]'
 })
 export class ChainSelectDirective {
-  constructor(private tpl: TemplateRef<any>) { }
+  constructor(public tpl: TemplateRef<any>) { }
 }

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.enum.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.enum.ts
@@ -1,0 +1,3 @@
+export enum ChainSelectEventEnum {
+  delete = 'delete',
+};

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.example.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.example.ts
@@ -40,19 +40,21 @@ export class ChainSingleSelectExampleComponent implements OnInit {
   }
 }
 
+export const template = `
+  <b-chain-select [actionLabel]="actionLabel"
+                  [selectedItemList]="selectedIdList"
+                  (selectChange)="change($event)">
+      <b-chain-single-select-example
+        *bChainSelect="let selected=selected; let selectChange=selectChange; let index=index"
+        [selectedId]="selected"
+        (selectChange)="selectChange($event, index)">
+      </b-chain-single-select-example>
+  </b-chain-select>
+`;
+
 @Component({
+  template,
   selector: 'b-chain-select-example',
-  template: `
-    <b-chain-select [actionLabel]="actionLabel"
-                    [selectedItemList]="selectedIdList"
-                    (selectChange)="change($event)">
-        <b-chain-single-select-example
-          *bChainSelect="let selected=selected; let selectChange=selectChange; let index=index"
-          [selectedId]="selected"
-          (selectChange)="selectChange($event, index)">
-        </b-chain-single-select-example>
-    </b-chain-select>
-  `
 })
 export class ChainSelectExampleComponent {
   public selectedIdList = [1, 2, 3];

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.example.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.example.ts
@@ -43,10 +43,9 @@ export class ChainSingleSelectExampleComponent implements OnInit {
 @Component({
   selector: 'b-chain-select-example',
   template: `
-    <b-chain-select [selectComponent]="selectComponent"
-                    [selectComponentConfig]="selectComponentConfig"
-                    [actionLabel]="actionLabel"
+    <b-chain-select [actionLabel]="actionLabel"
                     (selectChange)="change($event)">
+        <b-chain-single-select-example *bChainSelect></b-chain-single-select-example>
     </b-chain-select>
   `
 })

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.example.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.example.ts
@@ -7,6 +7,7 @@ import { SelectGroupOption } from '../list.interface';
 @Component({
   selector: 'b-chain-single-select-example',
   template: `
+  <ng-content></ng-content>
     <b-single-select [options]="options" (selectChange)="change($event)">
     </b-single-select>
   `,
@@ -44,18 +45,15 @@ export class ChainSingleSelectExampleComponent implements OnInit {
   selector: 'b-chain-select-example',
   template: `
     <b-chain-select [actionLabel]="actionLabel"
+                    [selectedItemList]="selectedIdList"
                     (selectChange)="change($event)">
-        <b-chain-single-select-example *bChainSelect></b-chain-single-select-example>
+        <b-chain-single-select-example *bChainSelect="let selected" [selectedId]="selected">
+        </b-chain-single-select-example>
     </b-chain-select>
   `
 })
 export class ChainSelectExampleComponent {
-  public selectComponent = ChainSingleSelectExampleComponent;
-  public selectComponentConfig = {
-    selectedIdKey: 'selectedId',
-    outputKey: 'selectChange',
-    selectedIds: [1, 2, 3],
-  };
+  public selectedIdList = [1, 2, 3];
   public actionLabel = 'Add another';
   @Output() selectChange: EventEmitter<any> = new EventEmitter<any>();
 

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.example.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.example.ts
@@ -58,7 +58,7 @@ export const template = `
 })
 export class ChainSelectExampleComponent {
   public selectedIdList = [1, 2, 3];
-  public actionLabel = 'Add another';
+  @Input() actionLabel: string;
   @Output() selectChange: EventEmitter<any> = new EventEmitter<any>();
 
   public change($event) {

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.example.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.example.ts
@@ -7,7 +7,6 @@ import { SelectGroupOption } from '../list.interface';
 @Component({
   selector: 'b-chain-single-select-example',
   template: `
-  <ng-content></ng-content>
     <b-single-select [options]="options" (selectChange)="change($event)">
     </b-single-select>
   `,
@@ -15,7 +14,7 @@ import { SelectGroupOption } from '../list.interface';
 export class ChainSingleSelectExampleComponent implements OnInit {
   @Input() selectedId: number;
   public options: SelectGroupOption[];
-  public selectChange: EventEmitter<any> = new EventEmitter<any>();
+  @Output() selectChange: EventEmitter<any> = new EventEmitter<any>();
 
   ngOnInit(): void {
     this.options = [{
@@ -47,7 +46,10 @@ export class ChainSingleSelectExampleComponent implements OnInit {
     <b-chain-select [actionLabel]="actionLabel"
                     [selectedItemList]="selectedIdList"
                     (selectChange)="change($event)">
-        <b-chain-single-select-example *bChainSelect="let selected" [selectedId]="selected">
+        <b-chain-single-select-example
+          *bChainSelect="let selected=selected; let selectChange=selectChange; let index=index"
+          [selectedId]="selected"
+          (selectChange)="selectChange($event, index)">
         </b-chain-single-select-example>
     </b-chain-select>
   `

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.interface.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.interface.ts
@@ -1,14 +1,8 @@
-import {
-  RenderedComponent
-} from '../../../services/component-renderer/component-renderer.interface';
+import { ChainSelectEventEnum } from './chain-select.enum';
 
-export interface ChainLink {
-  selectComponentConfig: RenderedComponent;
-}
+type ChainSelectEventType = ChainSelectEventEnum | Object;
 
-export interface SelectComponentConfig {
-  outputKey: string;
-  selectedIdKey?: string;
-  selectedIds?: (string | number)[];
-  filterFn?: (value: any) => boolean;
+export interface ChainSelectEvent {
+  event: ChainSelectEventType
+  index: number,
 }

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.module.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.module.ts
@@ -1,18 +1,14 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ChainSelectComponent } from './chain-select.component';
 import { IconsModule } from '../../../icons/icons.module';
-import {
-  ComponentRendererModule
-} from '../../../services/component-renderer/component-renderer.module';
 import { ButtonsModule } from '../../../buttons/buttons.module';
+import { ChainSelectComponent } from './chain-select.component';
 import { ChainSelectDirective } from './chain-select.directive';
 
 @NgModule({
   imports: [
     CommonModule,
     IconsModule,
-    ComponentRendererModule,
     ButtonsModule,
   ],
   declarations: [

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.module.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.module.ts
@@ -6,6 +6,7 @@ import {
   ComponentRendererModule
 } from '../../../services/component-renderer/component-renderer.module';
 import { ButtonsModule } from '../../../buttons/buttons.module';
+import { ChainSelectDirective } from './chain-select.directive';
 
 @NgModule({
   imports: [
@@ -16,9 +17,11 @@ import { ButtonsModule } from '../../../buttons/buttons.module';
   ],
   declarations: [
     ChainSelectComponent,
+    ChainSelectDirective,
   ],
   exports: [
     ChainSelectComponent,
+    ChainSelectDirective,
   ],
 })
 export class ChainSelectModule { }

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.stories.ts
@@ -10,7 +10,12 @@ const buttonStories = storiesOf(ComponentGroupType.Lists, module).addDecorator(
   withKnobs
 );
 
-const template = `<b-chain-select-example (selectChange)="selectChange($event)"></b-chain-select-example>`;
+const template = `
+<b-chain-select-example
+  [actionLabel]="actionLabel"
+  (selectChange)="selectChange($event)">
+</b-chain-select-example>
+`;
 
 const storyTemplate = `
 <b-story-book-layout [title]="'Chain select'">
@@ -43,7 +48,8 @@ buttonStories.add(
   () => ({
     template: storyTemplate,
     props: {
-      selectChange: action('Chain select event')
+      selectChange: action('Chain select event'),
+      actionLabel: text('action label', 'Add another'),
     },
     moduleMetadata: {
       imports: [StoryBookLayoutModule, ChainSelectExampleModule],

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.stories.ts
@@ -4,7 +4,7 @@ import { action } from '@storybook/addon-actions';
 import { ComponentGroupType } from '../../../consts';
 import { StoryBookLayoutModule } from '../../../story-book-layout/story-book-layout.module';
 import { SingleSelectComponent } from '../single-select/single-select.component';
-import { ChainSelectExampleModule } from './chain-select.example';
+import { ChainSelectExampleModule, template as exampleTemplate } from './chain-select.example';
 
 const buttonStories = storiesOf(ComponentGroupType.Lists, module).addDecorator(
   withKnobs
@@ -29,15 +29,12 @@ const note = `
   #### Properties
   Name | Type | Description | Default value
   --- | --- | --- | ---
-  selectComponent | Type | Select component to chain | none
   actionLabel | string | action label text | none
-  outputKey | string | key of event emitter in selectComponent | none
-  selectChange | action | returns object with listChange and index each time a select in the chain is changed | none
-  selectedIds | (string or number)[] | selected values for each selectComponent | none (Optional)
-  selectedIdKey | string | key of selected values input in selectComponent | none (Optional)
+  selectChange | action | EventEmitter - emits ChainSelectEvent | none
+  selectedItemList | (any)[] | selected values for each select | none (Optional)
 
   ~~~
-  ${template}
+  ${exampleTemplate}
   ~~~
 `;
 
@@ -46,7 +43,7 @@ buttonStories.add(
   () => ({
     template: storyTemplate,
     props: {
-      selectChange: action('Chain select state')
+      selectChange: action('Chain select event')
     },
     moduleMetadata: {
       imports: [StoryBookLayoutModule, ChainSelectExampleModule],

--- a/projects/ui-framework/src/public_api.ts
+++ b/projects/ui-framework/src/public_api.ts
@@ -220,7 +220,10 @@ export {
 
 // Chain select
 export {
-  SelectComponentConfig
+  ChainSelectEventEnum
+} from './lib/form-elements/lists/chain-select/chain-select.enum';
+export {
+  ChainSelectEvent
 } from './lib/form-elements/lists/chain-select/chain-select.interface';
 export {
   ChainSelectComponent


### PR DESCRIPTION
Modify Chain Select component to use structural directive instead of Component Renderer.

Main Change:

Chain Select is a component that accepts any Component and creates a list to which the user can add or remove copies of the input component.

The first version of Chain Select uses Component Renderer to handle the input component.
This PR does it with a structural directive.

The pros of this approach:
- No need for input configuration for the component, everything is done in the mark up.
- No need to use component renderer

Secondary Change:

Chain Select used to hold a state of all select elements inside of it.
This was a leaky abstraction, since Chain Select couldn't know how to translate its input state into select output.
The new version holds no state and emits single change events plus index, instead of a list of changes.