### PR TITLE
chain select: represent chain links as object

### DIFF
--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.spec.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.spec.ts
@@ -34,7 +34,7 @@ describe('EmployeeChainSelectComponent', () => {
   describe('addChainLink', () => {
     it('Should add chain link to the list', () => {
       component.addChainLink();
-      expect(component.chainLinkList).toEqual([null, null]);
+      expect(component.chainLinkList).toEqual([{}, {}]);
       fixture.detectChanges();
       const rows = fixture.debugElement.queryAll(By.css('.chain-link-row'));
       expect(rows.length).toEqual(2);
@@ -64,6 +64,6 @@ describe('EmployeeChainSelectComponent', () => {
       spyOn(component.selectChange, 'emit');
       component.handleChange({}, 0);
       expect(component.selectChange.emit).toHaveBeenCalledWith({ event: {}, index: 0 });
-    })
+    });
   });
 });

--- a/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.ts
+++ b/projects/ui-framework/src/lib/form-elements/lists/chain-select/chain-select.component.ts
@@ -13,7 +13,7 @@ import { ChainSelectEventEnum } from './chain-select.enum';
 })
 export class ChainSelectComponent implements OnInit {
   @Input() actionLabel: string;
-  @Input() selectedItemList: any[] = [null];
+  @Input() selectedItemList: any[];
   @Output() selectChange: EventEmitter<ChainSelectEvent> =
     new EventEmitter<ChainSelectEvent>();
 
@@ -27,11 +27,15 @@ export class ChainSelectComponent implements OnInit {
   @ContentChild(ChainSelectDirective, { static: true }) contentChild !: ChainSelectDirective;
 
   ngOnInit() {
-    this.chainLinkList = cloneDeep(this.selectedItemList);
+    if (this.selectedItemList && this.selectedItemList.length) {
+      this.chainLinkList = cloneDeep(this.selectedItemList);
+    } else {
+      this.chainLinkList = [{}];
+    }
   }
 
   public addChainLink() {
-    this.chainLinkList.push(null);
+    this.chainLinkList.push({});
   }
 
   public removeChainLink(index: number) {


### PR DESCRIPTION
This one is in order to fix tracking by ngFor.
Since all new values in the chain select are represented by null, and since null has the same reference for all null 'instances', ngFor treats them as the same object and the tracking gets messed up.