### PR TITLE
added text hyphenation to truncate tooltip for webkit browsers

### DIFF
--- a/projects/ui-framework/src/lib/style/line-clamp.scss
+++ b/projects/ui-framework/src/lib/style/line-clamp.scss
@@ -34,6 +34,10 @@ $selector: '';
   mask-position: center bottom, center top;
   mask-repeat: no-repeat;
 
+  @supports (hyphens: auto) or (-webkit-hyphens: auto) {
+    @include text-hyphenate;
+  }
+
   @supports (-webkit-line-clamp: 2) {
     display: -webkit-box !important;
     -webkit-box-orient: vertical;


### PR DESCRIPTION
will hyphenate words (break words with '-' with correct language rules) in webkit browsers.

this is to address this issue: https://github.com/hibobio/hibob/issues/27213 