### PR TITLE
Pavel/RTE inline toolbar

### DIFF
--- a/projects/ui-framework/bob-rte/src/rte/rte.abstract.ts
+++ b/projects/ui-framework/bob-rte/src/rte/rte.abstract.ts
@@ -144,30 +144,7 @@ export abstract class RTEbaseElement extends BaseFormElement
 
     if (changes.options) {
       this.updateEditorOptions(
-        merge(RTE_OPTIONS_DEF, this.options, changes.options.currentValue),
-        () => {
-          if (
-            !changes.options.firstChange &&
-            changes.options.previousValue.toolbarInline !== true &&
-            changes.options.currentValue.toolbarInline === true
-          ) {
-            this.editor.toolbar.hide();
-            this.editor.toolbar['_init']();
-            this.editor.toolbar.showInline();
-          }
-          if (
-            !changes.options.firstChange &&
-            changes.options.previousValue.toolbarInline === true &&
-            changes.options.currentValue.toolbarInline === false
-          ) {
-            document.querySelector('.fr-toolbar.fr-inline').remove();
-            (this.getEditorElement() as HTMLElement).classList.remove(
-              'fr-inline'
-            );
-            (this.getEditorElement('.fr-toolbar') as HTMLElement).remove();
-            this.editor.toolbar['_init']();
-          }
-        }
+        merge(RTE_OPTIONS_DEF, this.options, changes.options.currentValue)
       );
     }
 
@@ -401,7 +378,7 @@ export abstract class RTEbaseElement extends BaseFormElement
     const requestedElements = editorHostElem.querySelectorAll(selector);
     return requestedElements.length < 2
       ? requestedElements[0]
-      : requestedElements;
+      : Array.from(requestedElements);
   }
 
   protected getEditorTextbox(): HTMLElement {
@@ -426,7 +403,7 @@ export abstract class RTEbaseElement extends BaseFormElement
     }
   }
 
-  public updateEditorOptions(
+  protected updateEditorOptions(
     options: Partial<FroalaOptions>,
     callback: Function = null
   ): void {

--- a/projects/ui-framework/bob-rte/src/rte/rte.abstract.ts
+++ b/projects/ui-framework/bob-rte/src/rte/rte.abstract.ts
@@ -33,6 +33,7 @@ import {
   ABOVE_END,
   IconColor,
   isNotEmptyObject,
+  isEmptyArray,
 } from 'bob-style';
 
 import {
@@ -386,14 +387,19 @@ export abstract class RTEbaseElement extends BaseFormElement
 
   protected updateToolbar(): void {
     if (this.toolbarButtons) {
-      this.toolbarButtons.forEach(b => {
-        const cmd = b.getAttribute('data-cmd') as BlotType;
-        if (!this.controls.includes(cmd)) {
-          b.setAttribute('hidden', 'true');
-        } else {
-          b.removeAttribute('hidden');
-        }
-      });
+      if (isEmptyArray(this.controls)) {
+        this.editor.toolbar.hide();
+      } else {
+        this.toolbarButtons.forEach(b => {
+          const cmd = b.getAttribute('data-cmd') as BlotType;
+          if (!this.controls.includes(cmd)) {
+            b.setAttribute('hidden', 'true');
+          } else {
+            b.removeAttribute('hidden');
+          }
+        });
+        this.editor.toolbar.show();
+      }
     }
   }
 

--- a/projects/ui-framework/bob-rte/src/rte/rte.abstract.ts
+++ b/projects/ui-framework/bob-rte/src/rte/rte.abstract.ts
@@ -144,7 +144,30 @@ export abstract class RTEbaseElement extends BaseFormElement
 
     if (changes.options) {
       this.updateEditorOptions(
-        merge(RTE_OPTIONS_DEF, this.options, changes.options.currentValue)
+        merge(RTE_OPTIONS_DEF, this.options, changes.options.currentValue),
+        () => {
+          if (
+            !changes.options.firstChange &&
+            changes.options.previousValue.toolbarInline !== true &&
+            changes.options.currentValue.toolbarInline === true
+          ) {
+            this.editor.toolbar.hide();
+            this.editor.toolbar['_init']();
+            this.editor.toolbar.showInline();
+          }
+          if (
+            !changes.options.firstChange &&
+            changes.options.previousValue.toolbarInline === true &&
+            changes.options.currentValue.toolbarInline === false
+          ) {
+            document.querySelector('.fr-toolbar.fr-inline').remove();
+            (this.getEditorElement() as HTMLElement).classList.remove(
+              'fr-inline'
+            );
+            (this.getEditorElement('.fr-toolbar') as HTMLElement).remove();
+            this.editor.toolbar['_init']();
+          }
+        }
       );
     }
 

--- a/projects/ui-framework/bob-rte/src/rte/rte.component.scss
+++ b/projects/ui-framework/bob-rte/src/rte/rte.component.scss
@@ -19,6 +19,7 @@
   border: 1px solid $input-border-color;
   border-radius: $border-radius;
   transition: box-shadow 0.2s, border-color 0.2s;
+  overflow: hidden;
 }
 
 .bfe-wrap:focus,

--- a/projects/ui-framework/bob-rte/src/rte/rte.component.ts
+++ b/projects/ui-framework/bob-rte/src/rte/rte.component.ts
@@ -61,7 +61,7 @@ export class RichTextEditorComponent extends RTEbaseElement implements OnInit {
 
         this.editor = this.getEditor();
 
-        if (this.options.tooltips === false) {
+        if (this.options.tooltips === false && this.toolbarButtons) {
           this.toolbarButtons.forEach(b => {
             b.setAttribute('aria-label', b.getAttribute('title'));
             b.removeAttribute('title');

--- a/projects/ui-framework/bob-rte/src/rte/rte.const.ts
+++ b/projects/ui-framework/bob-rte/src/rte/rte.const.ts
@@ -30,23 +30,25 @@ export const RTE_TOOLBAR_HEIGHT = 41;
 
 export const RTE_OPTIONS_DEF: FroalaOptions = {
   key: 'DUA2yE3G1A1A5B8B1pZGCTRSAPJWTLPLZHTQQe1JGZxC4B3A3B2B5B1C1E4I1B3==',
-
-  heightMin: RTE_MINHEIGHT_DEF - RTE_TOOLBAR_HEIGHT,
-  heightMax: RTE_MAXHEIGHT_DEF - RTE_TOOLBAR_HEIGHT,
+  attribution: false,
 
   enter: 1,
   initOnClick: false,
   theme: 'royal',
+  fontFamily: {
+    '\'Gotham SSm A\', \'Gotham SSm B\', \'Helvetica\'': 'Body font',
+    '\'Sentinel SSm A\', \'Sentinel SSm B\', \'Helvetica\'': 'Heading font',
+  },
+  scrollableContainer: 'body',
 
-  attribution: false,
-  toolbarBottom: true,
-  toolbarSticky: false,
+  heightMin: RTE_MINHEIGHT_DEF - RTE_TOOLBAR_HEIGHT,
+  heightMax: RTE_MAXHEIGHT_DEF - RTE_TOOLBAR_HEIGHT,
+
   charCounterCount: true,
   charCounterMax: -1,
 
   tooltips: false,
   shortcutsHint: false,
-
   placeholderText: '',
 
   imagePaste: false,
@@ -146,8 +148,6 @@ export const RTE_OPTIONS_DEF: FroalaOptions = {
 
   wordDeniedTags: ['script', 'style'],
 
-  scrollableContainer: 'body',
-
   listAdvancedTypes: false,
 
   linkAlwaysBlank: true,
@@ -160,15 +160,11 @@ export const RTE_OPTIONS_DEF: FroalaOptions = {
 
   colorsText: [],
 
-  fontFamily: {
-    '\'Gotham SSm A\', \'Gotham SSm B\', \'Helvetica\'': 'Body font',
-    '\'Sentinel SSm A\', \'Sentinel SSm B\', \'Helvetica\'': 'Heading font',
-  },
-
+  toolbarBottom: true,
+  toolbarSticky: false,
   toolbarButtons: RTE_CONTROLS_DEF,
-
-  // toolbarInline: true,
-  // toolbarVisibleWithoutSelection: true,
+  toolbarInline: false,
+  toolbarVisibleWithoutSelection: true,
 
   pluginsEnabled: [
     'align',
@@ -206,6 +202,7 @@ export const RTE_OPTIONS_DEF: FroalaOptions = {
   ],
 
   emoticonsUseImage: false,
+  emoticonsButtons: [],
 
   emoticonsSet: EMOJI_DATA.map((cat: EmojiCategory) => ({
     name: cat.name,

--- a/projects/ui-framework/bob-rte/src/rte/rte.const.ts
+++ b/projects/ui-framework/bob-rte/src/rte/rte.const.ts
@@ -17,7 +17,7 @@ export const RTE_CONTROLS_DEF = joinArrays(
     BlotType.leftToRight,
     BlotType.emoticons,
     BlotType.mentions,
-    BlotType.placeholder
+    BlotType.placeholder,
   ],
   Object.values(BlotType)
 );
@@ -77,7 +77,7 @@ export const RTE_OPTIONS_DEF: FroalaOptions = {
     'contenteditable',
     'spellcheck',
     'tabindex',
-    '.*mention.*'
+    '.*mention.*',
 
     // 'align',
     // 'border',
@@ -93,7 +93,7 @@ export const RTE_OPTIONS_DEF: FroalaOptions = {
     'font-weight',
     'font-style',
     'text-align',
-    'direction'
+    'direction',
   ],
   htmlAllowedTags: [
     'a',
@@ -118,7 +118,7 @@ export const RTE_OPTIONS_DEF: FroalaOptions = {
     'h3',
     'h4',
     'h5',
-    'h6'
+    'h6',
 
     // 'caption',
     // 'code',
@@ -162,10 +162,13 @@ export const RTE_OPTIONS_DEF: FroalaOptions = {
 
   fontFamily: {
     '\'Gotham SSm A\', \'Gotham SSm B\', \'Helvetica\'': 'Body font',
-    '\'Sentinel SSm A\', \'Sentinel SSm B\', \'Helvetica\'': 'Heading font'
+    '\'Sentinel SSm A\', \'Sentinel SSm B\', \'Helvetica\'': 'Heading font',
   },
 
   toolbarButtons: RTE_CONTROLS_DEF,
+
+  // toolbarInline: true,
+  // toolbarVisibleWithoutSelection: true,
 
   pluginsEnabled: [
     'align',
@@ -180,7 +183,7 @@ export const RTE_OPTIONS_DEF: FroalaOptions = {
     'paragraphStyle',
     'save',
     'url',
-    'emoticons'
+    'emoticons',
     // 'fontFamily',
     // 'table',
     // 'video',
@@ -211,9 +214,9 @@ export const RTE_OPTIONS_DEF: FroalaOptions = {
     emoticons: cat.data.map((icn: Emoji) => ({
       code: icn.code,
       desc: icn.description,
-      icon: icn.icon
-    }))
-  })) as any
+      icon: icn.icon,
+    })),
+  })) as any,
 };
 
 export const RTE_MENTIONS_OPTIONS_DEF: TributeOptions = {
@@ -232,6 +235,6 @@ export const RTE_MENTIONS_OPTIONS_DEF: TributeOptions = {
 
   searchOpts: {
     pre: '<em class="match">',
-    post: '</em>'
-  }
+    post: '</em>',
+  },
 };

--- a/projects/ui-framework/bob-rte/src/rte/rte.stories.ts
+++ b/projects/ui-framework/bob-rte/src/rte/rte.stories.ts
@@ -8,7 +8,7 @@ import {
   object,
   select,
   text,
-  withKnobs
+  withKnobs,
 } from '@storybook/addon-knobs/angular';
 import { action } from '@storybook/addon-actions';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -76,6 +76,7 @@ const template = `
       [description]="description"
       [controls]="controls"
       [disableControls]="disableControls"
+      [options]="{ toolbarInline: toolbarInline }"
       [mentionsList]="mentionsList"
       [placeholderList]="placeholderList"
       [minChars]="minChars"
@@ -120,16 +121,18 @@ const note = `
   Name | Type | Description | default
   --- | --- | --- | ---
   [type] | RTEType | theme: primary (white bg, border), secondary (transparent bg, no borders), tertiary (grey bg, no borders) | primary
-  [label] | string | label text (above editor) | &nbsp;
-  [placeholder] | string | placeholder text (inside editor) | &nbsp;
-  [description] | string | description text (icon tooltip) | &nbsp;
-  [hideLabelOnFocus] | boolean | if true label text will be used as placeholder | false
   [value] | string | html content to be placed inside editor | &nbsp;
   [controls] | BlotType[] | array of toolbar controls (check BlotType enum for all possible controls). Defaults to all controls. Pass empty array to disable all controls | all
+  [disableControls] | BlotType[] | array of toolbar controls to disable. <u>Hint:</u> if you need to disable 1-2 controls from the default set, dont set [controls], just pass controls you want disabled in [disableControls] instead. | []
+  [options] | FroalaOptions | <u>Experimental!</u> additional options for Froala editor. [See Docs](https://www.froala.com/wysiwyg-editor/docs/options). Try \`{ toolbarInline:true }\` to get inline toolbar (regular toolbar will be hidden)
   [minChars] | number | minimum (plain) text length | 0
   [maxChars] | number | maximum (plain) text length | &nbsp;
   [minHeight] | number | minimum height of editor (including toolbar). Set to **0** to disable min-height | 185
   [maxHeight] | number | maximum height of editor (including toolbar). Set to **0** to disable max-height | 350
+  [label] | string | label text (above editor) | &nbsp;
+  [placeholder] | string | placeholder text (inside editor) | &nbsp;
+  [description] | string | description text (icon tooltip) | &nbsp;
+  [hideLabelOnFocus] | boolean | if true label text will be used as placeholder | false
   [disabled] | boolean | disables editor | false
   [required] | boolean | adds * to placeholder | false
   [hintMessage] | string | adds a hint message below editor | &nbsp;
@@ -211,28 +214,31 @@ inputStories.add(
         hintMessage: text('hintMessage', 'This field should contain something'),
         warnMessage: text('warnMessage', ''),
         errorMessage: text('errorMessage', ''),
+
         controls: array('controls', controlsDef, '\n'),
         disableControls: array('disableControls', disableControlsDef, '\n'),
+        toolbarInline: boolean('toolbarInline', false),
+
         value: text('value', value),
         placeholderList: object<SelectGroupOption>('options', placeholderMock),
         mentionsList: object('mentionsList', mentionsOptions),
         change: action('Value changed'),
         focus: action('Editor focused'),
-        blur: action('Editor blurred')
+        blur: action('Editor blurred'),
       },
       moduleMetadata: {
         imports: [
           BrowserAnimationsModule,
           StoryBookLayoutModule,
-          RichTextEditorModule
-        ]
-      }
+          RichTextEditorModule,
+        ],
+      },
     };
   },
   {
     notes: { markdown: note },
     knobs: {
-      escapeHTML: false
-    }
+      escapeHTML: false,
+    },
   }
 );

--- a/projects/ui-framework/bob-rte/src/rte/rte.stories.ts
+++ b/projects/ui-framework/bob-rte/src/rte/rte.stories.ts
@@ -76,7 +76,6 @@ const template = `
       [description]="description"
       [controls]="controls"
       [disableControls]="disableControls"
-      [options]="{ toolbarInline: toolbarInline }"
       [mentionsList]="mentionsList"
       [placeholderList]="placeholderList"
       [minChars]="minChars"
@@ -217,7 +216,6 @@ inputStories.add(
 
         controls: array('controls', controlsDef, '\n'),
         disableControls: array('disableControls', disableControlsDef, '\n'),
-        toolbarInline: boolean('toolbarInline', false),
 
         value: text('value', value),
         placeholderList: object<SelectGroupOption>('options', placeholderMock),

--- a/projects/ui-framework/src/lib/style/rte/rte.scss
+++ b/projects/ui-framework/src/lib/style/rte/rte.scss
@@ -151,6 +151,13 @@ $link-color: var(--primary-700);
 
 .fr-toolbar.fr-basic {
   background: transparent;
+  position: relative !important;
+
+  &[style*='top'] {
+    display: block !important;
+    left: auto !important;
+    top: auto !important;
+  }
 }
 
 .fr-btn[hidden] {

--- a/projects/ui-framework/src/lib/style/rte/rte.scss
+++ b/projects/ui-framework/src/lib/style/rte/rte.scss
@@ -15,7 +15,7 @@ $link-color: var(--primary-700);
 
 .fr-toolbar,
 .fr-wrapper,
-.fr-box.fr-basic .fr-element,
+.fr-box[class] .fr-element,
 .fr-view {
   @include b-body($color: $display-text-color, $lineHeight: null);
 }
@@ -25,7 +25,7 @@ $link-color: var(--primary-700);
   line-height: $line-height-body;
 }
 
-.fr-box.fr-basic .fr-element,
+.fr-box[class] .fr-element,
 .fr-view {
   line-height: $rte-lineheight;
 
@@ -54,7 +54,7 @@ $link-color: var(--primary-700);
   color: $grey-600;
 }
 
-.fr-box.fr-basic {
+.fr-box[class] {
   display: flex;
   flex-direction: column;
 
@@ -71,24 +71,24 @@ $link-color: var(--primary-700);
   }
 }
 
-.fr-box.fr-basic .fr-element {
+.fr-box[class] .fr-element {
   padding: 12px 15px;
 }
 
 // borders
 
-.fr-box.fr-basic {
+.fr-box[class] {
   border-radius: $border-radius;
 }
 
-.fr-box.fr-basic,
+.fr-box[class],
 .fr-toolbar.fr-bottom,
 .fr-toolbar.fr-top {
   border-color: inherit;
 }
 
-.fr-box.fr-basic.fr-top,
-.fr-box.fr-basic.fr-bottom {
+.fr-box[class].fr-top,
+.fr-box[class].fr-bottom {
   .fr-wrapper {
     border-radius: $border-radius $border-radius 0 0;
     border-width: 0;
@@ -149,7 +149,7 @@ $link-color: var(--primary-700);
 
 // toolbar
 
-.fr-toolbar {
+.fr-toolbar.fr-basic {
   background: transparent;
 }
 
@@ -322,10 +322,12 @@ $link-color: var(--primary-700);
   overflow: hidden;
 }
 
+.fr-toolbar.fr-inline,
 .fr-command.fr-btn.fr-active + .fr-dropdown-menu,
 .fr-popup {
   @include OverlayPanel(null, null);
 }
+.fr-toolbar.fr-inline,
 .fr-command.fr-btn.fr-active + .fr-dropdown-menu,
 .fr-popup,
 .fr-popup.fr-above {


### PR DESCRIPTION
- if all controls are disabled, no toolbar is shown (previously would show empty toolbar)
- [options] input for extended Froala config published to story

 