### PR TITLE
pavel/indicatorColor config option for collapsible section

### DIFF
--- a/projects/ui-framework/src/lib/chips/chip/chip.module.ts
+++ b/projects/ui-framework/src/lib/chips/chip/chip.module.ts
@@ -1,13 +1,12 @@
 import { NgModule } from '@angular/core';
 import { ChipComponent } from './chip.component';
 import { CommonModule } from '@angular/common';
-import { ColorService } from '../../services/color-service/color.service';
 import { IconsModule } from '../../icons/icons.module';
 
 @NgModule({
   declarations: [ChipComponent],
   imports: [CommonModule, IconsModule],
   exports: [ChipComponent],
-  providers: []
+  providers: [],
 })
 export class ChipModule {}

--- a/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section-example.module.ts
+++ b/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section-example.module.ts
@@ -5,7 +5,7 @@ import {
   SimpleChanges,
   OnChanges,
   Output,
-  EventEmitter
+  EventEmitter,
 } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { CollapsibleSectionModule } from './collapsible-section.module';
@@ -15,13 +15,12 @@ import {
   mockAvatar,
   mockNames,
   mockJobs,
-  mockDate,
   mockText,
-  mockDateRange
+  mockDateRange,
 } from '../../mock.const';
 import {
   LabelValueType,
-  IconPosition
+  IconPosition,
 } from '../../typography/label-value/label-value.enum';
 import { randomNumber, makeArray } from '../../services/utils/functional-utils';
 import { ButtonsModule } from '../../buttons/buttons.module';
@@ -192,8 +191,8 @@ import { InputModule } from '../../form-elements/input/input.module';
     ':host::ng-deep .avatars { margin-top: 4px; }',
     ':host::ng-deep .avatars b-avatar { margin-right: 16px; }',
     ':host::ng-deep .avatars b-avatar:last-child { margin-right: 0; }',
-    ':host::ng-deep .avatars b-avatar:after {min-width: 200px; text-align: center; }'
-  ]
+    ':host::ng-deep .avatars b-avatar:after {min-width: 200px; text-align: center; }',
+  ],
 })
 export class CollapsibleSectionExample1Component implements OnChanges {
   constructor() {}
@@ -211,43 +210,43 @@ export class CollapsibleSectionExample1Component implements OnChanges {
   public avatar = {
     imageSource: mockAvatar(),
     label: mockNames(1),
-    value: mockJobs(1)
+    value: mockJobs(1),
   };
   public holiday = {
     label: mockDateRange(this.daysNum),
     value: 'Holiday',
     icon: Icons.doc_icon,
-    iconPosition: IconPosition.left
+    iconPosition: IconPosition.left,
   };
   public days = {
     label: this.daysNum,
-    value: 'Days'
+    value: 'Days',
   };
   public cancelButton = {
     type: ButtonType.tertiary,
     color: IconColor.negative,
     size: ButtonSize.medium,
-    icon: Icons.close
+    icon: Icons.close,
   };
   public confirmButton = {
     type: ButtonType.tertiary,
     color: IconColor.positive,
     size: ButtonSize.medium,
-    icon: Icons.tick
+    icon: Icons.tick,
   };
   public curBalance = {
     label: 'Current balance',
-    value: randomNumber(2, 8) + '.' + randomNumber(10, 90)
+    value: randomNumber(2, 8) + '.' + randomNumber(10, 90),
   };
   public docs = {
     label: 'Docs',
     value: mockText(1) + '.pdf',
     icon: Icons.doc,
-    iconPosition: IconPosition.value
+    iconPosition: IconPosition.value,
   };
   public reason = {
     label: 'Reason',
-    value: '"I\'m planning a trip to celebrate my birthday."'
+    value: '"I\'m planning a trip to celebrate my birthday."',
   };
   public outHolidayNum = 3;
   public outHoliday = {
@@ -255,8 +254,8 @@ export class CollapsibleSectionExample1Component implements OnChanges {
     avatars: makeArray(this.outHolidayNum).map(i => ({
       imageSource: mockAvatar(),
       size: AvatarSize.mini,
-      tooltip: mockNames(1) + '\n' + mockDateRange() + '\n' + 'Approved'
-    }))
+      tooltip: mockNames(1) + '\n' + mockDateRange() + '\n' + 'Approved',
+    })),
   };
   public outWorkNum = 5;
   public outWork = {
@@ -264,8 +263,8 @@ export class CollapsibleSectionExample1Component implements OnChanges {
     avatars: makeArray(this.outWorkNum).map(i => ({
       imageSource: mockAvatar(),
       size: AvatarSize.mini,
-      tooltip: mockNames(1) + '\n' + mockDateRange() + '\n' + 'Approved'
-    }))
+      tooltip: mockNames(1) + '\n' + mockDateRange() + '\n' + 'Approved',
+    })),
   };
   public outMilitaryNum = 2;
   public outMilitary = {
@@ -273,8 +272,8 @@ export class CollapsibleSectionExample1Component implements OnChanges {
     avatars: makeArray(this.outMilitaryNum).map(i => ({
       imageSource: mockAvatar(),
       size: AvatarSize.mini,
-      tooltip: mockNames(1) + '\n' + mockDateRange() + '\n' + 'Approved'
-    }))
+      tooltip: mockNames(1) + '\n' + mockDateRange() + '\n' + 'Approved',
+    })),
   };
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -297,7 +296,6 @@ export class CollapsibleSectionExample1Component implements OnChanges {
   template: `
     <b-collapsible-section
       [title]="title"
-      [titleColor]="titleColor"
       [description]="description"
       [collapsible]="collapsible"
       [expanded]="expanded"
@@ -330,8 +328,8 @@ export class CollapsibleSectionExample1Component implements OnChanges {
     '.cell { width: 48%; margin-bottom: 16px; }',
     '.cell:nth-last-child(1), .cell:nth-last-child(2) { margin-bottom: 0; }',
     'b-button {margin-right: 8px;}',
-    'b-button:last-child {margin-right: 0;}'
-  ]
+    'b-button:last-child {margin-right: 0;}',
+  ],
 })
 export class CollapsibleSectionExample2Component implements OnChanges {
   constructor() {}
@@ -342,7 +340,6 @@ export class CollapsibleSectionExample2Component implements OnChanges {
   @Input() divided = true;
 
   @Input() title = mockText(randomNumber(2, 5));
-  @Input() titleColor = '#5555ff';
   @Input() description = mockText(randomNumber(3, 6));
 
   @Output() opened: EventEmitter<void> = new EventEmitter<void>();
@@ -353,13 +350,14 @@ export class CollapsibleSectionExample2Component implements OnChanges {
   public buttonText1 = mockText(1);
   public buttonText2 = mockText(1);
   public options = {
-    headerContentClickable: false
+    headerContentClickable: false,
+    indicatorColor: '#cc2748',
   };
 
   public formCells = makeArray(6).map(i => ({
     label: mockText(randomNumber(1, 2)),
     placeholder: mockText(randomNumber(2, 4)),
-    hint: mockText(randomNumber(3, 6))
+    hint: mockText(randomNumber(3, 6)),
   }));
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -379,7 +377,7 @@ export class CollapsibleSectionExample2Component implements OnChanges {
 @NgModule({
   declarations: [
     CollapsibleSectionExample1Component,
-    CollapsibleSectionExample2Component
+    CollapsibleSectionExample2Component,
   ],
   imports: [
     BrowserModule,
@@ -388,11 +386,11 @@ export class CollapsibleSectionExample2Component implements OnChanges {
     AvatarModule,
     TypographyModule,
     ButtonsModule,
-    InputModule
+    InputModule,
   ],
   exports: [
     CollapsibleSectionExample1Component,
-    CollapsibleSectionExample2Component
-  ]
+    CollapsibleSectionExample2Component,
+  ],
 })
 export class CollapsibleSectionExampleModule {}

--- a/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.html
+++ b/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.html
@@ -23,8 +23,7 @@
          [ngClass]="{'bcp-title-wrap-column': options?.titlesAsColumn}">
 
       <h4 class="bcp-title"
-          [ngClass]="{'b-display-3': !options?.smallTitle, 'b-bold-body': options?.smallTitle}"
-          [ngStyle]="{'color': titleColor}">{{title}}</h4>
+          [ngClass]="{'b-display-3': !options?.smallTitle, 'b-bold-body': options?.smallTitle}">{{title}}</h4>
 
       <p *ngIf="description"
          class="bcp-description">{{description}}</p>

--- a/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.spec.ts
+++ b/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, async, TestBed } from '@angular/core/testing';
 import {
   NO_ERRORS_SCHEMA,
   Component,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy,
 } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { CollapsibleSectionComponent } from './collapsible-section.component';
@@ -14,8 +14,9 @@ import createSpyObj = jasmine.createSpyObj;
 import {
   elementFromFixture,
   emitNativeEvent,
-  simpleChange
+  simpleChange,
 } from '../../services/utils/test-helpers';
+import { ColorService } from '../../services/color-service/color.service';
 
 @Component({
   template: `
@@ -24,7 +25,7 @@ import {
       <div class="test-content" style="height: 300px;">content</div>
     </b-collapsible-section>
   `,
-  providers: []
+  providers: [],
 })
 class TestComponent {
   constructor() {}
@@ -48,14 +49,15 @@ describe('CollapsibleSectionComponent', () => {
       imports: [],
       declarations: [TestComponent, CollapsibleSectionComponent],
       providers: [
+        ColorService,
         DOMhelpers,
         { provide: UtilsService, useValue: utilsServiceStub },
-        EventManagerPlugins[0]
+        EventManagerPlugins[0],
       ],
-      schemas: [NO_ERRORS_SCHEMA]
+      schemas: [NO_ERRORS_SCHEMA],
     })
       .overrideComponent(CollapsibleSectionComponent, {
-        set: { changeDetection: ChangeDetectionStrategy.Default }
+        set: { changeDetection: ChangeDetectionStrategy.Default },
       })
       .compileComponents()
       .then(() => {
@@ -154,7 +156,7 @@ describe('CollapsibleSectionComponent', () => {
       collapsibleComponent.expanded = true;
       collapsibleComponent.ngOnChanges(
         simpleChange({
-          expanded: true
+          expanded: true,
         })
       );
       collapsiblePanel = elementFromFixture(fixture, '.bcp-panel');
@@ -216,7 +218,7 @@ describe('CollapsibleSectionComponent', () => {
       collapsibleComponent.disabled = true;
       collapsibleComponent.ngOnChanges(
         simpleChange({
-          disabled: true
+          disabled: true,
         })
       );
 
@@ -232,8 +234,9 @@ describe('CollapsibleSectionComponent', () => {
       collapsibleComponent.ngOnChanges(
         simpleChange({
           options: {
-            headerTranscludeStopPropagation: true
-          }
+            headerTranscludeStopPropagation: true,
+            indicatorColor: '#cc2748',
+          },
         })
       );
 
@@ -252,6 +255,17 @@ describe('CollapsibleSectionComponent', () => {
       emitNativeEvent(collapsibleHeader, 'click');
       collapsiblePanel = elementFromFixture(fixture, '.bcp-panel');
       expect(collapsiblePanel).toBeTruthy();
+    });
+
+    it('should set css color variables, if indicatorColor prop is passed', () => {
+      const panel = elementFromFixture(fixture, 'b-collapsible-section');
+
+      expect(getComputedStyle(panel).getPropertyValue('--bcp-color')).toEqual(
+        '#cc2748'
+      );
+      expect(
+        getComputedStyle(panel).getPropertyValue('--bcp-color-rgb')
+      ).toEqual('204, 39, 72');
     });
   });
 });

--- a/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.ts
+++ b/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.ts
@@ -12,30 +12,31 @@ import {
   SimpleChanges,
   OnChanges,
   OnInit,
-  OnDestroy
+  OnDestroy,
 } from '@angular/core';
 import { DOMhelpers } from '../../services/html/dom-helpers.service';
 import {
   simpleUID,
   notFirstChanges,
-  cloneObject
+  cloneObject,
 } from '../../services/utils/functional-utils';
 import { UtilsService } from '../../services/utils/utils.service';
 import { Subscription } from 'rxjs';
 import { outsideZone } from '../../services/utils/rxjs.operators';
 import { CollapsibleOptions } from './collapsible-section.interface';
+import { ColorService } from '../../services/color-service/color.service';
 
 const collapsibleOptionsDef: CollapsibleOptions = {
   smallTitle: false,
   titlesAsColumn: true,
-  headerTranscludeStopPropagation: false
+  headerTranscludeStopPropagation: false,
 };
 
 @Component({
   selector: 'b-collapsible-section',
   templateUrl: './collapsible-section.component.html',
   styleUrls: ['./collapsible-section.component.scss'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CollapsibleSectionComponent
   implements OnChanges, OnInit, AfterViewInit, OnDestroy {
@@ -44,7 +45,8 @@ export class CollapsibleSectionComponent
     private utilsService: UtilsService,
     private DOM: DOMhelpers,
     private zone: NgZone,
-    private cd: ChangeDetectorRef
+    private cd: ChangeDetectorRef,
+    private colorService: ColorService
   ) {}
 
   public panelID = simpleUID('bcp-');
@@ -62,7 +64,6 @@ export class CollapsibleSectionComponent
   @Input() divided = true;
 
   @Input() title: string;
-  @Input() titleColor?: string;
   @Input() description?: string;
 
   @Input() options: CollapsibleOptions = cloneObject(collapsibleOptionsDef);
@@ -77,8 +78,23 @@ export class CollapsibleSectionComponent
     if (changes.options) {
       this.options = {
         ...collapsibleOptionsDef,
-        ...changes.options.currentValue
+        ...changes.options.currentValue,
       };
+
+      if (this.options.indicatorColor) {
+        const colorRGB = this.colorService.parseToRGB(
+          this.options.indicatorColor
+        );
+
+        if (colorRGB) {
+          this.DOM.setCssProps(this.host.nativeElement, {
+            '--bcp-color': this.options.indicatorColor,
+            '--bcp-color-rgb': this.colorService
+              .parseToRGB(this.options.indicatorColor)
+              .join(', '),
+          });
+        }
+      }
     }
 
     if (changes.expanded) {
@@ -162,7 +178,7 @@ export class CollapsibleSectionComponent
           : 500;
 
       this.DOM.setCssProps(this.host.nativeElement, {
-        '--panel-height': this.contentHeight + 'px'
+        '--panel-height': this.contentHeight + 'px',
       });
     }
 

--- a/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.interface.ts
+++ b/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.interface.ts
@@ -2,4 +2,5 @@ export interface CollapsibleOptions {
   smallTitle?: boolean;
   titlesAsColumn?: boolean;
   headerTranscludeStopPropagation?: boolean;
+  indicatorColor?: string;
 }

--- a/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.module.ts
+++ b/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.module.ts
@@ -6,11 +6,12 @@ import { CollapsibleSectionComponent } from './collapsible-section.component';
 import { UtilsModule } from '../../services/utils/utils.module';
 import { DOMhelpers } from '../../services/html/dom-helpers.service';
 import { EventManagerPlugins } from '../../services/utils/eventManager.plugins';
+import { ColorService } from '../../services/color-service/color.service';
 
 @NgModule({
   declarations: [CollapsibleSectionComponent],
   imports: [CommonModule, TypographyModule, MatExpansionModule, UtilsModule],
   exports: [CollapsibleSectionComponent],
-  providers: [DOMhelpers, EventManagerPlugins[0]]
+  providers: [DOMhelpers, ColorService, EventManagerPlugins[0]],
 })
 export class CollapsibleSectionModule {}

--- a/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.stories.ts
+++ b/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.stories.ts
@@ -5,7 +5,7 @@ import {
   text,
   array,
   object,
-  withKnobs
+  withKnobs,
 } from '@storybook/addon-knobs/angular';
 import { action } from '@storybook/addon-actions';
 import { ComponentGroupType } from '../../consts';
@@ -27,7 +27,6 @@ const template = `
     [disabled]="disabled"
     [divided]="divided"
     [title]="title"
-    [titleColor]="titleColor"
     [description]="description"
     [options]="options"
     (closed)="onPanelClosed($event)"
@@ -63,7 +62,6 @@ const storyTemplate = `
 
    <b-collapsible-section-example-2
       [title]="title"
-      [titleColor]="titleColor"
       [description]="description"
       [collapsible]="collapsible"
       [expanded]="expanded"
@@ -91,12 +89,11 @@ const note = `
   [expanded] | boolean | if the panel is expanded (open) | false
   [disabled] | boolean | if the panel is disabled (can't be opened) | false
   [divided] | boolean | if the panel has a divider between the header and the content | true
-  [title] | string | section title | none
-  [titleColor] | string | color for the title | none
-  [description] | string | section description (subtitle) | none
-  [options] | CollapsibleOptions | additional options, among which: <br> **options.headerTranscludeStopPropagation** - set to true to prevent click event propagation from content transcluded in header (for example, to prevent buttons opening/closing the panel) | false
-  (opened) |  EventEmitter | emits when collapsible panel was opened | none
-  (closed) |  EventEmitter | emits when collapsible panel was closed | none
+  [title] | string | section title | &nbsp;
+  [description] | string | section description (subtitle) | &nbsp;
+  [options] | CollapsibleOptions | additional options, among which: <br> **options.headerTranscludeStopPropagation** - set to true to prevent click event propagation from content transcluded in header (for example, to prevent buttons opening/closing the panel)<br>**options.indicatorColor** - will add \`--bcp-color\` and \`--bcp-color-rgb\` css variables, that you can use for custom color mods in your feature css. | collapsibleOptionsDef
+  (opened) |  EventEmitter | emits when collapsible panel was opened | &nbsp;
+  (closed) |  EventEmitter | emits when collapsible panel was closed | &nbsp;
 
   Content marked with [header] attribute will be projected into the  header (if Title text is present, the [header] content will be placed to the right of the Title, if no Title is present, [header] content will take the full width of header).
 
@@ -118,10 +115,9 @@ story.add(
         disabled: boolean('disabled', false),
         divided: boolean('divided', true),
         title: text('title', mockText(randomNumber(2, 5))),
-        titleColor: text('titleColor', '#5555ff'),
         description: text('description', mockText(randomNumber(3, 6))),
         onPanelOpened: action('Panel opened'),
-        onPanelClosed: action('Panel closed')
+        onPanelClosed: action('Panel closed'),
       },
       moduleMetadata: {
         declarations: [],
@@ -129,10 +125,10 @@ story.add(
           StoryBookLayoutModule,
           BrowserAnimationsModule,
           CollapsibleSectionModule,
-          CollapsibleSectionExampleModule
+          CollapsibleSectionExampleModule,
         ],
-        entryComponents: []
-      }
+        entryComponents: [],
+      },
     };
   },
   { notes: { markdown: note } }

--- a/projects/ui-framework/src/lib/services/color-service/color.service.spec.ts
+++ b/projects/ui-framework/src/lib/services/color-service/color.service.spec.ts
@@ -8,10 +8,32 @@ describe('ColorService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [ColorService],
-      schemas: [NO_ERRORS_SCHEMA]
+      schemas: [NO_ERRORS_SCHEMA],
     });
 
     colorService = TestBed.get(ColorService);
+  });
+
+  describe('parseToRGB', () => {
+    it('should convert "rgba(66,66,66,0)"', () => {
+      expect(colorService.parseToRGB('rgba(66,66,66,0)')).toEqual([66, 66, 66]);
+    });
+
+    it('should convert "rgb(33,33,33)"', () => {
+      expect(colorService.parseToRGB('rgba(33,33,33)')).toEqual([33, 33, 33]);
+    });
+
+    it('should convert "#0000FF"', () => {
+      expect(colorService.parseToRGB('#0000FF')).toEqual([0, 0, 255]);
+    });
+
+    it('should convert "0000FF"', () => {
+      expect(colorService.parseToRGB('0000FF')).toEqual([0, 0, 255]);
+    });
+
+    it('should convert "#f00"', () => {
+      expect(colorService.parseToRGB('#f00')).toEqual([255, 0, 0]);
+    });
   });
 
   describe('isDark', () => {

--- a/projects/ui-framework/src/lib/services/color-service/color.service.ts
+++ b/projects/ui-framework/src/lib/services/color-service/color.service.ts
@@ -4,27 +4,35 @@ import { Injectable } from '@angular/core';
 export class ColorService {
   constructor() {}
 
-  private parseRGBcolor(color: string) {
-    const colorArr = color.match(/\d+/g);
+  public hexToRgb(hex: string): number[] {
+    const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+    hex = hex.replace(shorthandRegex, function(m, r, g, b) {
+      return r + r + g + g + b + b;
+    });
 
-    return colorArr && colorArr.length > 2
+    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+
+    return result
       ? [
-          parseInt(colorArr[0], 10),
-          parseInt(colorArr[1], 10),
-          parseInt(colorArr[2], 10)
+          parseInt(result[1], 16),
+          parseInt(result[2], 16),
+          parseInt(result[3], 16),
         ]
       : undefined;
   }
 
-  private getBrightness(color: number[]): number {
-    return !color
-      ? undefined
-      : (color[0] * 299 + color[1] * 587 + color[2] * 114) / 1000;
+  public rgbToHex(rgb: number[]): string {
+    return (
+      '#' +
+      this.componentToHex(rgb[0]) +
+      this.componentToHex(rgb[1]) +
+      this.componentToHex(rgb[2])
+    );
   }
 
   public isDark(color: number[] | string) {
     if (typeof color === 'string') {
-      color = this.parseRGBcolor(color);
+      color = this.parseToRGB(color);
     }
     const brightness = this.getBrightness(color);
     return brightness && brightness < 160; // 128
@@ -34,5 +42,28 @@ export class ColorService {
     return (
       '#' + (0x1000000 + Math.random() * 0xffffff).toString(16).substr(1, 6)
     );
+  }
+
+  public parseToRGB(color: string): number[] {
+    const colorArr = color.match(/\d+/g);
+
+    return colorArr && colorArr.length > 2
+      ? [
+          parseInt(colorArr[0], 10),
+          parseInt(colorArr[1], 10),
+          parseInt(colorArr[2], 10),
+        ]
+      : this.hexToRgb(color);
+  }
+
+  private componentToHex(c: number): string {
+    const hex = c.toString(16);
+    return hex.length === 1 ? '0' + hex : hex;
+  }
+
+  private getBrightness(color: number[]): number {
+    return !color
+      ? undefined
+      : (color[0] * 299 + color[1] * 587 + color[2] * 114) / 1000;
   }
 }


### PR DESCRIPTION
- providing options.indicatorColor will set --bcp-color and --bcp-color-rgb variables on the component, that can be used in feature css for custom color mods
- updated colorsService with rgbToHex, hexToRgb methods and better parseToRGB