### PR TITLE
Pavel/Menu update

### DIFF
--- a/projects/ui-framework/src/lib/buttons/back-button/back-button.component.spec.ts
+++ b/projects/ui-framework/src/lib/buttons/back-button/back-button.component.spec.ts
@@ -13,18 +13,22 @@ describe('BackButtonComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [MockComponent(ButtonComponent), BackButtonComponent]
+      declarations: [MockComponent(ButtonComponent), BackButtonComponent],
     })
       .compileComponents()
       .then(() => {
         fixture = TestBed.createComponent(BackButtonComponent);
         component = fixture.componentInstance;
-        buttonElement = fixture.debugElement.query(By.css('button'))
-          .nativeElement;
+        buttonElement = fixture.debugElement.query(By.css('button')).nativeElement;
+        component.clicked.subscribe(() => {});
         spyOn(component.clicked, 'emit');
         fixture.detectChanges();
       });
   }));
+
+  afterEach(() => {
+    component.clicked.complete();
+  });
 
   it('should show button component with back icon and button size small', () => {
     expect(buttonElement.classList).toContain(Icons.back_arrow_link);

--- a/projects/ui-framework/src/lib/buttons/button/button.component.spec.ts
+++ b/projects/ui-framework/src/lib/buttons/button/button.component.spec.ts
@@ -16,24 +16,28 @@ describe('ButtonComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ButtonComponent],
       providers: [],
-      imports: [MatButtonModule, IconsModule]
+      imports: [MatButtonModule, IconsModule],
     })
       .compileComponents()
       .then(() => {
         fixture = TestBed.createComponent(ButtonComponent);
         component = fixture.componentInstance;
-        buttonElement = fixture.debugElement.query(By.css('button'))
-          .nativeElement;
+        buttonElement = fixture.debugElement.query(By.css('button')).nativeElement;
+        component.clicked.subscribe(() => {});
         spyOn(component.clicked, 'emit');
         fixture.detectChanges();
       });
   }));
 
+  afterEach(() => {
+    component.clicked.complete();
+  });
+
   describe('onClick', () => {
     it('Should emit the click event', () => {
       const e = {
         id: 1,
-        stopPropagation: () => true
+        stopPropagation: () => true,
       } as any;
       component.onClick(e);
       expect(component.clicked.emit).toHaveBeenCalledWith(e);
@@ -70,10 +74,7 @@ describe('ButtonComponent', () => {
   });
 
   describe('OnChanges', () => {
-    const testColor = (
-      buttonType: ButtonType,
-      expectedColor: IconColor
-    ): void => {
+    const testColor = (buttonType: ButtonType, expectedColor: IconColor): void => {
       component.type = buttonType;
       component.icon = Icons.timeline;
       fixture.detectChanges();

--- a/projects/ui-framework/src/lib/buttons/chevron-button/chevron-button.component.spec.ts
+++ b/projects/ui-framework/src/lib/buttons/chevron-button/chevron-button.component.spec.ts
@@ -8,17 +8,22 @@ describe('ChevronButtonComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ChevronButtonComponent]
+      declarations: [ChevronButtonComponent],
     })
       .compileComponents()
       .then(() => {
         fixture = TestBed.createComponent(ChevronButtonComponent);
         component = fixture.componentInstance;
+        component.clicked.subscribe(() => {});
         spyOn(component.clicked, 'emit');
         component.text = 'Click';
         fixture.detectChanges();
       });
   }));
+
+  afterEach(() => {
+    component.clicked.complete();
+  });
 
   describe('Inputs', () => {
     it('should display text in the button', () => {
@@ -36,9 +41,7 @@ describe('ChevronButtonComponent', () => {
       fixture.detectChanges();
       const button = fixture.debugElement.query(By.css('button'));
 
-      expect(button.nativeElement.classList).not.toContain(
-        'b-icon-chevron-down'
-      );
+      expect(button.nativeElement.classList).not.toContain('b-icon-chevron-down');
       expect(button.nativeElement.classList).toContain('b-icon-chevron-up');
     });
   });
@@ -47,7 +50,7 @@ describe('ChevronButtonComponent', () => {
     it('should emit clicked', () => {
       const e = {
         id: 1,
-        stopPropagation: () => true
+        stopPropagation: () => true,
       } as any;
       component.onClick(e);
       expect(component.clicked.emit).toHaveBeenCalledWith(e);

--- a/projects/ui-framework/src/lib/buttons/square/square.component.spec.ts
+++ b/projects/ui-framework/src/lib/buttons/square/square.component.spec.ts
@@ -16,24 +16,28 @@ describe('SquareButtonComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [SquareButtonComponent, MockComponent(IconComponent)],
-      imports: [MatButtonModule]
+      imports: [MatButtonModule],
     })
       .compileComponents()
       .then(() => {
         fixture = TestBed.createComponent(SquareButtonComponent);
         component = fixture.componentInstance;
         component.icon = Icons.file_copy;
-        buttonElement = fixture.debugElement.query(By.css('button'))
-          .nativeElement;
+        buttonElement = fixture.debugElement.query(By.css('button')).nativeElement;
+        component.clicked.subscribe(() => {});
         spyOn(component.clicked, 'emit');
         fixture.detectChanges();
       });
   }));
 
+  afterEach(() => {
+    component.clicked.complete();
+  });
+
   describe('onClick', () => {
     it('Should emit the click event', () => {
       const e = {
-        id: 1
+        id: 1,
       } as any;
       component.onClick(e);
       expect(component.clicked.emit).toHaveBeenCalledWith(e);

--- a/projects/ui-framework/src/lib/buttons/text-button/text-button.component.spec.ts
+++ b/projects/ui-framework/src/lib/buttons/text-button/text-button.component.spec.ts
@@ -15,16 +15,21 @@ describe('TextButtonComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [MockComponent(IconComponent), TextButtonComponent],
-      imports: [TypographyModule]
+      imports: [TypographyModule],
     })
       .compileComponents()
       .then(() => {
         fixture = TestBed.createComponent(TextButtonComponent);
         component = fixture.componentInstance;
         element = fixture.debugElement.nativeElement;
+        component.clicked.subscribe(() => {});
         spyOn(component.clicked, 'emit');
       });
   }));
+
+  afterEach(() => {
+    component.clicked.complete();
+  });
 
   it('should display input text', () => {
     component.text = 'Button text';
@@ -43,9 +48,7 @@ describe('TextButtonComponent', () => {
     expect(element.children.length).toEqual(1);
     expect(element.children[0].className).toContain(Icons.home);
     expect(element.children[0].className).toContain('b-icon-' + IconColor.dark);
-    expect(element.children[0].className).toContain(
-      'b-icon-' + IconSize.medium
-    );
+    expect(element.children[0].className).toContain('b-icon-' + IconSize.medium);
   });
 
   it('should set color to orange for component and icon', () => {
@@ -53,9 +56,7 @@ describe('TextButtonComponent', () => {
     component.color = LinkColor.primary;
     fixture.detectChanges();
     expect(element.classList).toContain('color-primary');
-    expect(element.children[0].className).toContain(
-      'b-icon-' + IconColor.primary
-    );
+    expect(element.children[0].className).toContain('b-icon-' + IconColor.primary);
   });
 
   it('should emit clicked when clicking the component', () => {

--- a/projects/ui-framework/src/lib/buttons/text-button/text-button.component.ts
+++ b/projects/ui-framework/src/lib/buttons/text-button/text-button.component.ts
@@ -1,11 +1,4 @@
-import {
-  Component,
-  EventEmitter,
-  HostBinding,
-  HostListener,
-  Input,
-  Output,
-} from '@angular/core';
+import { Component, EventEmitter, HostBinding, HostListener, Input, Output } from '@angular/core';
 import { IconColor, IconSize } from '../../icons/icons.enum';
 import { LinkColor } from '../../buttons-indicators/link/link.enum';
 import { BaseButtonElement } from '../button.abstract';
@@ -32,7 +25,9 @@ export class TextButtonComponent extends BaseButtonElement {
 
   @HostListener('click', ['$event'])
   onClick($event: MouseEvent) {
-    this.clicked.emit($event);
+    if (this.clicked.observers.length > 0) {
+      this.clicked.emit($event);
+    }
   }
 
   getIconClass(): string {

--- a/projects/ui-framework/src/lib/navigation/menu/menu.component.html
+++ b/projects/ui-framework/src/lib/navigation/menu/menu.component.html
@@ -1,12 +1,12 @@
 <content [matMenuTriggerFor]="childMenu"
          (menuOpened)="onOpenMenu()"
+         (menuClosed)="onCloseMenu()"
          [ngClass]="{'disabled': disabled}"
          class="menu-trigger-wrapper">
   <ng-content select="[menu-trigger]"></ng-content>
 </content>
 
 <mat-menu #childMenu="matMenu"
-          (closed)="onCloseMenu()"
           [xPosition]="menuDir">
   <span *ngFor="let child of menu">
     <!-- Handle branch node menu menu -->
@@ -18,15 +18,17 @@
               [disableRipple]="true">
         <span>{{child.label}}</span>
       </button>
-      <b-menu #menu [menu]="child.children"
-              [openLeft]="openLeft">
+      <b-menu #menu
+              [menu]="child.children"
+              [openLeft]="openLeft"
+              (actionClick)="onClick($event, false)">
       </b-menu>
     </span>
     <!-- Handle leaf node menu menu -->
     <span *ngIf="!child.children || child.children.length === 0">
       <button mat-menu-item
               class="{{child?.key}}"
-              (click)="onClick($event, child)"
+              (click)="onClick(child)"
               [ngClass]="{'disabled': child.disabled}"
               [disableRipple]="true">
         <span>{{child.label}}</span>

--- a/projects/ui-framework/src/lib/navigation/menu/menu.component.spec.ts
+++ b/projects/ui-framework/src/lib/navigation/menu/menu.component.spec.ts
@@ -4,6 +4,7 @@ import { MenuComponent } from './menu.component';
 import { MatMenuModule } from '@angular/material/menu';
 import { By } from '@angular/platform-browser';
 import { MenuItem } from './menu.interface';
+import { CommonModule } from '@angular/common';
 
 describe('MenuComponent', () => {
   let component: MenuComponent;
@@ -15,127 +16,155 @@ describe('MenuComponent', () => {
       {
         label: 'button 0',
         key: 'button.zero',
-        action: $event => console.log('button 0', $event),
+        action: $event => console.log('button 0', $event)
       },
       {
         label: 'button 1',
-        action: $event => console.log('button 1', $event),
+        action: $event => console.log('button 1', $event)
       },
       {
         label: 'button 2',
         children: [
           {
             label: 'button 3',
-            action: $event => console.log('button 3', $event),
+            action: $event => console.log('button 3', $event)
           },
           {
             label: 'button 4',
-            action: $event => console.log('button 4', $event),
-          },
-        ],
-      },
+            action: $event => console.log('button 4', $event)
+          }
+        ]
+      }
     ];
 
     TestBed.configureTestingModule({
       declarations: [MenuComponent],
-      imports: [NoopAnimationsModule, MatMenuModule],
+      imports: [CommonModule, NoopAnimationsModule, MatMenuModule]
     })
       .compileComponents()
       .then(() => {
         fixture = TestBed.createComponent(MenuComponent);
         component = fixture.componentInstance;
+        component.id = 'menu_id';
+        component.menu = menuMock;
+        component.actionClick.subscribe(() => {});
+        component.openMenu.subscribe(() => {});
+        component.closeMenu.subscribe(() => {});
+        fixture.detectChanges();
         spyOn(component.actionClick, 'emit');
         spyOn(component.openMenu, 'emit');
         spyOn(component.closeMenu, 'emit');
       });
   }));
 
+  afterEach(() => {
+    component.actionClick.complete();
+    component.openMenu.complete();
+    component.closeMenu.complete();
+  });
+
   describe('menu', () => {
     const openMenu = () => {
-      const menuTrigger = fixture.debugElement.query(
-        By.css('.menu-trigger-wrapper')
-      );
+      const menuTrigger = fixture.debugElement.query(By.css('.menu-trigger-wrapper'));
       menuTrigger.triggerEventHandler('click', null);
     };
+
     it('should open menu on menuTrigger click', () => {
-      component.menu = menuMock;
-      fixture.detectChanges();
       let menu = fixture.debugElement.query(By.css('.mat-menu-panel'));
       expect(menu).toBeFalsy();
       openMenu();
       menu = fixture.debugElement.query(By.css('.mat-menu-panel'));
       expect(menu).toBeTruthy();
     });
-    it('should emit openMenu event when opening menu', () => {
-      component.menu = menuMock;
-      fixture.detectChanges();
+
+    it('should emit openMenu event when opening menu (with menu id)', () => {
       openMenu();
       expect(component.openMenu.emit).toHaveBeenCalledTimes(1);
+      expect(component.openMenu.emit).toHaveBeenCalledWith('menu_id');
     });
+
     it('should have 3 options in menu', () => {
-      component.menu = menuMock;
-      fixture.detectChanges();
       openMenu();
-      const menuOptions = fixture.debugElement.queryAll(
-        By.css('.mat-menu-item')
-      );
+      const menuOptions = fixture.debugElement.queryAll(By.css('.mat-menu-item'));
       expect(menuOptions.length).toEqual(3);
     });
+
     it('should display label in option', () => {
-      component.menu = menuMock;
-      fixture.detectChanges();
       openMenu();
-      const menuOptions = fixture.debugElement.queryAll(
-        By.css('.mat-menu-item span')
-      );
+      const menuOptions = fixture.debugElement.queryAll(By.css('.mat-menu-item span'));
       expect(menuOptions[0].nativeElement.innerText).toEqual('button 0');
       expect(menuOptions[1].nativeElement.innerText).toEqual('button 1');
       expect(menuOptions[2].nativeElement.innerText).toEqual('button 2');
     });
+
+    it('should display deep options', () => {
+      openMenu();
+      let menuOptions = fixture.debugElement.queryAll(By.css('.mat-menu-item span'));
+
+      menuOptions[2].nativeElement.click();
+      menuOptions = fixture.debugElement.queryAll(By.css('.mat-menu-item'));
+
+      expect(menuOptions[3].nativeElement.innerText).toEqual('button 3');
+      expect(menuOptions[4].nativeElement.innerText).toEqual('button 4');
+    });
+
     it('should invoke the action from the config', () => {
-      spyOn(menuMock[1], 'action');
-      component.menu = menuMock;
-      fixture.detectChanges();
+      spyOn(component.menu[1], 'action');
       openMenu();
-      const menuOption = fixture.debugElement.queryAll(
-        By.css('.mat-menu-item')
-      )[1];
+      const menuOption = fixture.debugElement.queryAll(By.css('.mat-menu-item'))[1];
       menuOption.triggerEventHandler('click', null);
-      expect(menuMock[1].action).toHaveBeenCalledTimes(1);
+      expect(component.menu[1].action).toHaveBeenCalledTimes(1);
     });
-    it('should invoke actionClick on menu action click', () => {
-      spyOn(menuMock[1], 'action');
-      component.menu = menuMock;
-      fixture.detectChanges();
+
+    it('should invoke actionClick on menu action click, should output menu item, enriched with menu id', () => {
+      spyOn(component.menu[1], 'action');
       openMenu();
-      const menuOption = fixture.debugElement.queryAll(
-        By.css('.mat-menu-item')
-      )[1];
+      const menuOption = fixture.debugElement.queryAll(By.css('.mat-menu-item'))[1];
+
       menuOption.triggerEventHandler('click', null);
-      expect(component.actionClick.emit).toHaveBeenCalledWith(menuMock[1]);
+
+      expect(component.actionClick.emit).toHaveBeenCalledWith({
+        ...component.menu[1],
+        id: 'menu_id'
+      });
+      expect(component.menu[1].action).toHaveBeenCalledTimes(1);
     });
+
+    it('should invoke actionClick on deep menu action click, should output menu item, enriched with menu id', () => {
+      spyOn(component.menu[2].children[1], 'action');
+      openMenu();
+
+      let menuOptions = fixture.debugElement.queryAll(By.css('.mat-menu-item'));
+
+      menuOptions[2].nativeElement.click();
+      menuOptions = fixture.debugElement.queryAll(By.css('.mat-menu-item'));
+      menuOptions[4].triggerEventHandler('click', null);
+
+      menuOptions[1].triggerEventHandler('click', null);
+
+      expect(component.actionClick.emit).toHaveBeenCalledWith({
+        ...component.menu[2].children[1],
+        id: 'menu_id'
+      });
+      expect(component.menu[2].children[1].action).toHaveBeenCalledTimes(1);
+    });
+
     it('should disable option when config has disabled=true', () => {
-      menuMock[1] = {
+      component.menu[1] = {
         label: 'button 2',
         action: $event => console.log('button 2', $event),
-        disabled: true,
+        disabled: true
       };
-      spyOn(menuMock[1], 'action');
-      component.menu = menuMock;
       fixture.detectChanges();
+
       openMenu();
-      const menuOption = fixture.debugElement.queryAll(
-        By.css('.mat-menu-item')
-      )[1];
+      const menuOption = fixture.debugElement.queryAll(By.css('.mat-menu-item'))[1];
       expect(menuOption.nativeElement.classList).toContain('disabled');
     });
+
     it('should add class from config key', () => {
-      component.menu = menuMock;
-      fixture.detectChanges();
       openMenu();
-      const menuOption = fixture.debugElement.queryAll(
-        By.css('.mat-menu-item')
-      )[0];
+      const menuOption = fixture.debugElement.queryAll(By.css('.mat-menu-item'))[0];
       expect(menuOption.nativeElement.classList).toContain('button.zero');
     });
   });
@@ -147,8 +176,8 @@ describe('MenuComponent', () => {
           previousValue: undefined,
           currentValue: true,
           firstChange: true,
-          isFirstChange: () => true,
-        },
+          isFirstChange: () => true
+        }
       });
       expect(component.menuDir).toEqual('before');
     });
@@ -158,8 +187,8 @@ describe('MenuComponent', () => {
           previousValue: true,
           currentValue: false,
           firstChange: false,
-          isFirstChange: () => false,
-        },
+          isFirstChange: () => false
+        }
       });
       expect(component.menuDir).toEqual('after');
     });
@@ -169,14 +198,14 @@ describe('MenuComponent', () => {
           previousValue: undefined,
           currentValue: true,
           firstChange: true,
-          isFirstChange: () => true,
-        },
+          isFirstChange: () => true
+        }
       });
       fixture.detectChanges();
-      const menuTrigger = fixture.debugElement.query(
-        By.css('.menu-trigger-wrapper')
-      );
+      const menuTrigger = fixture.debugElement.query(By.css('.menu-trigger-wrapper'));
       expect(menuTrigger.nativeElement.classList).toContain('disabled');
     });
   });
+
+  describe('Events', () => {});
 });

--- a/projects/ui-framework/src/lib/navigation/menu/menu.component.ts
+++ b/projects/ui-framework/src/lib/navigation/menu/menu.component.ts
@@ -6,48 +6,54 @@ import { has } from 'lodash';
 @Component({
   selector: 'b-menu',
   templateUrl: './menu.component.html',
-  styleUrls: ['./menu.component.scss'],
+  styleUrls: ['./menu.component.scss']
 })
 export class MenuComponent implements OnChanges {
-
+  @Input() id: string;
   @Input() menu: MenuItem[];
   @Input() openLeft = false;
   @Input() disabled: boolean;
-  @Output() actionClick: EventEmitter<void> = new EventEmitter<void>();
-  @Output() openMenu: EventEmitter<void> = new EventEmitter<void>();
-  @Output() closeMenu: EventEmitter<void> = new EventEmitter<void>();
+  @Output() actionClick: EventEmitter<MenuItem> = new EventEmitter<MenuItem>();
+  @Output() openMenu: EventEmitter<string | void> = new EventEmitter<string | void>();
+  @Output() closeMenu: EventEmitter<string | void> = new EventEmitter<string | void>();
 
   @ViewChild('childMenu', { static: true }) public childMenu;
 
   menuDir: MenuPositionX = 'after';
 
-  constructor() {
-  }
+  constructor() {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (has(changes, 'openLeft')) {
       this.openLeft = changes.openLeft.currentValue;
-      this.menuDir = this.openLeft
-        ? 'before'
-        : 'after';
+      this.menuDir = this.openLeft ? 'before' : 'after';
     }
     if (has(changes, 'disabled')) {
       this.disabled = changes.disabled.currentValue;
     }
   }
 
-  onClick($event, child): void {
-    if (child.action) {
-      child.action($event);
+  onClick(child: MenuItem, triggerAction = true): void {
+    const childUpd = Object.assign({}, child, this.id ? { id: this.id } : {});
+
+    if (this.actionClick.observers.length > 0) {
+      this.actionClick.emit(childUpd);
     }
-    this.actionClick.emit(child);
+
+    if (child.action && triggerAction) {
+      child.action(childUpd);
+    }
   }
 
   onOpenMenu(): void {
-    this.openMenu.emit();
+    if (this.openMenu.observers.length > 0) {
+      this.openMenu.emit(this.id || null);
+    }
   }
 
   onCloseMenu(): void {
-    this.closeMenu.emit();
+    if (this.closeMenu.observers.length > 0) {
+      this.closeMenu.emit(this.id || null);
+    }
   }
 }

--- a/projects/ui-framework/src/lib/navigation/menu/menu.stories.ts
+++ b/projects/ui-framework/src/lib/navigation/menu/menu.stories.ts
@@ -1,13 +1,5 @@
 import { storiesOf } from '@storybook/angular';
-import {
-  array,
-  boolean,
-  number,
-  object,
-  select,
-  text,
-  withKnobs,
-} from '@storybook/addon-knobs/angular';
+import { array, boolean, number, object, select, text, withKnobs } from '@storybook/addon-knobs/angular';
 import { action } from '@storybook/addon-actions';
 import { ComponentGroupType } from '../../consts';
 import { ButtonType } from '../../buttons/buttons.enum';
@@ -19,17 +11,16 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { StoryBookLayoutModule } from '../../story-book-layout/story-book-layout.module';
 import { MenuItem } from './menu.interface';
 
-const story = storiesOf(ComponentGroupType.Navigation, module).addDecorator(
-  withKnobs
-);
+const story = storiesOf(ComponentGroupType.Navigation, module).addDecorator(withKnobs);
 
 const template = `
-<b-menu [menu]="menu"
+<b-menu [id]="'employee-menu'"
+        [menu]="menu"
         [openLeft]="openLeft"
         [disabled]="disabled"
-        (actionClick)="actionClick()"
-        (openMenu)="openMenu()"
-        (closeMenu)="closeMenu()">
+        (actionClick)="onActionClick($event)"
+        (openMenu)="onMenuOpen($event)"
+        (closeMenu)="onMenuClose($event)">
   <b-square-button menu-trigger
                    type="${ButtonType.secondary}"
                    icon="${Icons.three_dots}">
@@ -52,12 +43,14 @@ const note = `
   #### Properties
   Name | Type | Description | Default value
   --- | --- | --- | ---
-  menu | MenuItem[] | array of menu items | &nbsp;
-  openLeft | boolean | open left by default | false
-  disabled | boolean | disables menu | &nbsp;
-  actionClick | action | notifies on action click | &nbsp;
-  openMenu | action | notifies on menu open | &nbsp;
-  closeMenu | action | notifies on menu close | &nbsp;
+  [id] | string | menu id (can be used to reference the item, that has the menu) | &nbsp;
+  [menu] | MenuItem[] | array of menu items | &nbsp;
+  [openLeft] | boolean | open left by default | false
+  [disabled] | boolean | disables menu | &nbsp;
+  (actionClick) | &lt;MenuItem&gt; | notifies on action click, emits menu item, \
+  enriched with menu id (if present) | &nbsp;
+  (openMenu) | &lt;string / void&gt; | notifies on menu open, outputs menu's id, if present | &nbsp;
+  (closeMenu) | &lt;string / void&gt; | notifies on menu close, outputs menu's id, if present | &nbsp;
 
   ~~~
   ${template}
@@ -67,55 +60,68 @@ const note = `
 const menuMock: MenuItem[] = [
   {
     label: 'Employee',
+    key: 'employee',
+
     children: [
       {
         label: 'Update work details',
         key: 'update.work.details',
+
         children: [
           {
             label: 'Update site',
-            action: $event => console.log('update site', $event),
-            key: 'update.site',
+            action: action('update site'),
+            key: 'update.site'
           },
           {
             label: 'Update email',
-            action: $event => console.log('update email', $event),
+            action: action('update email'),
+            key: 'update.email'
           },
           {
             label: 'Update reports to',
             disabled: true,
-            action: $event => console.log('update reports to', $event),
-          },
-        ],
+            action: action('update reports to'),
+            key: 'update.reportsto'
+          }
+        ]
       },
+
       {
         label: 'Update internal details',
+        key: 'update.internal.details',
+
         children: [
           {
             label: 'Terminate',
-            action: $event => console.log('terminate', $event),
+            action: action('terminate'),
+            key: 'terminate123'
           },
           {
             label: 'Rehire',
-            action: $event => console.log('rehire', $event),
-          },
-        ],
+            action: action('rehire'),
+            key: 'rehire'
+          }
+        ]
       },
       {
         label: 'Delete file',
-        action: $event => console.log('delete file', $event),
-      },
-    ],
+        action: action('delete file'),
+        key: 'delete.file'
+      }
+    ]
   },
   {
     label: 'View profile',
-    action: $event => console.log('view profile', $event),
+    action: action('view profile'),
+    key: 'view.profile'
   },
   {
     label: 'Request time-off',
     disabled: true,
-    action: $event => console.log('request time off', $event),
-  },
+    action: action('request time off'),
+    key: 'request.timeoff'
+  }
 ];
 
 story.add(
@@ -127,19 +133,13 @@ story.add(
         openLeft: boolean('openLeft', false),
         disabled: boolean('disabled', false),
         menu: object('menu', menuMock),
-        actionClick: action('action click'),
-        openMenu: action('menu open'),
-        closeMenu: action('menu close'),
+        onActionClick: action('action click'),
+        onMenuOpen: action('menu open'),
+        onMenuClose: action('menu close')
       },
       moduleMetadata: {
-        imports: [
-          StoryBookLayoutModule,
-          BrowserAnimationsModule,
-          MenuModule,
-          ButtonsModule,
-          IconsModule,
-        ],
-      },
+        imports: [StoryBookLayoutModule, BrowserAnimationsModule, MenuModule, ButtonsModule, IconsModule]
+      }
     };
   },
   { notes: { markdown: note } }


### PR DESCRIPTION
fixed issues:
- menu didnt emit actionClick for deep menu items
- menu emitted multiple menuClosed events (equal to menu deepness)

added:
- id input for menu. all output events enriched with this id (can be used to reference the item, that has the menu)
- added more tests

+ little button test update