### PR TITLE
Pavel/RTE update 14 jan 20

### DIFF
--- a/projects/ui-framework/bob-rte/src/rte/placeholders.service.ts
+++ b/projects/ui-framework/bob-rte/src/rte/placeholders.service.ts
@@ -54,7 +54,7 @@ export class PlaceholdersConverterService {
     return name
       ? // prettier-ignore
         // tslint:disable-next-line: max-line-length
-        ` <span contenteditable="false" class="fr-deletable" data-placeholder-id="${id}"><em>{{&nbsp;</em>${(group ? '<strong>' + group + '</strong><em>&nbsp;-&nbsp;</em>' : '') + name}<em>&nbsp;}}</em></span> `
+        ` <span contenteditable="false" class="fr-deletable" data-placeholder-id="${id}" data-before="${group || ''}" data-after="${(group ? ' - ' : ' ') + name}"><em>—</em></span> `
       : id;
   }
 

--- a/projects/ui-framework/bob-rte/src/rte/placeholders.service.ts
+++ b/projects/ui-framework/bob-rte/src/rte/placeholders.service.ts
@@ -54,7 +54,7 @@ export class PlaceholdersConverterService {
     return name
       ? // prettier-ignore
         // tslint:disable-next-line: max-line-length
-        ` <span contenteditable="false" class="fr-deletable" data-placeholder-id="${id}" data-before="${group || ''}" data-after="${(group ? ' - ' : ' ') + name}"><em>—</em></span> `
+        ` <span contenteditable="false" class="fr-deletable" data-placeholder-id="${id}" data-before="${group || ''}" data-after="${(group ? ' - ' : '') + name}"><em>—</em></span> `
       : id;
   }
 

--- a/projects/ui-framework/bob-rte/src/rte/rte.abstract.ts
+++ b/projects/ui-framework/bob-rte/src/rte/rte.abstract.ts
@@ -466,4 +466,11 @@ export abstract class RTEbaseElement extends BaseFormElement
     }
     return this.length;
   }
+
+  protected getNativeRange(): Range {
+    const selection = document.getSelection();
+    return selection == null || selection.rangeCount <= 0
+      ? null
+      : selection.getRangeAt(0);
+  }
 }

--- a/projects/ui-framework/bob-rte/src/rte/rte.component.scss
+++ b/projects/ui-framework/bob-rte/src/rte/rte.component.scss
@@ -15,6 +15,7 @@
 
 .bfe-wrap {
   position: relative;
+  z-index: 0;
   background-color: white;
   border: 1px solid $input-border-color;
   border-radius: $border-radius;

--- a/projects/ui-framework/bob-rte/src/rte/rte.component.ts
+++ b/projects/ui-framework/bob-rte/src/rte/rte.component.ts
@@ -19,6 +19,7 @@ import {
   cloneArray,
   chainCall,
   eventHasMetaKey,
+  eventHasCntrlKey,
 } from 'bob-style';
 
 import { RTEbaseElement } from './rte.abstract';
@@ -73,6 +74,22 @@ export class RichTextEditorComponent extends RTEbaseElement
         }
 
         this.updateToolbar();
+
+        // cancel Ctrl+C events if selection is empty
+        this.editor.events.on(
+          'keydown',
+          (event: KeyboardEvent) => {
+            if (eventHasCntrlKey(event) && isKey(event.key, 'c')) {
+              const selection = this.getNativeRange();
+              if (selection.startOffset === selection.endOffset) {
+                event.preventDefault();
+                console.log('Copy prevented, because selection is empty');
+                return false;
+              }
+            }
+          },
+          true
+        );
 
         // init mentions
         if (this.mentionsEnabled()) {
@@ -185,18 +202,23 @@ export class RichTextEditorComponent extends RTEbaseElement
       },
 
       'window.copy': (event: ClipboardEvent) => {
+        if (!this.inputFocused) {
+          return;
+        }
         event.preventDefault();
+        this.editor.selection.save();
 
         const clipboardData: DataTransfer =
           event.clipboardData || event['originalEvent'].clipboardData;
-
-        const html = chainCall(
-          this.outputTransformers,
-          this.editor.html.getSelected()
+        const content = this.parserService.removeElements(
+          this.editor.html.getSelected(),
+          '.fr-marker'
         );
-
+        const html = chainCall(this.outputTransformers, content);
         clipboardData.setData('text/plain', html);
         clipboardData.setData('text/html', html);
+
+        this.editor.selection.restore();
       },
 
       'paste.afterCleanup': (html: string): string =>

--- a/projects/ui-framework/src/lib/services/html/html-parser.service.ts
+++ b/projects/ui-framework/src/lib/services/html/html-parser.service.ts
@@ -157,4 +157,15 @@ export class HtmlParserHelpers {
 
     return elm.innerHTML;
   }
+
+  public removeElements(value: string, selector: string): string {
+    if (!value || !selector) {
+      return value;
+    }
+    const elm: HTMLElement = document.createElement('div');
+    elm.innerHTML = value;
+
+    elm.querySelectorAll(selector).forEach(el => el.remove());
+    return elm.innerHTML;
+  }
 }

--- a/projects/ui-framework/src/lib/style/rte/rte-placeholders.scss
+++ b/projects/ui-framework/src/lib/style/rte/rte-placeholders.scss
@@ -11,21 +11,35 @@
     letter-spacing: normal;
     background-color: $grey-300;
     box-shadow: inset 0 0 0 1px white;
+    padding: 0 11px;
+    position: relative;
+    user-select: all;
 
     em {
-      &:first-child,
-      &:last-child {
-        letter-spacing: -1.5px;
+      @include size;
+      @include position(0 0 0 0);
+      text-align: center;
+      letter-spacing: 200px;
+      overflow: hidden;
+      color: transparent;
 
-        &,
-        &::selection {
-          color: transparent;
-        }
+      &::selection {
+        color: transparent;
       }
     }
 
-    strong {
+    &:before,
+    &:after {
+      pointer-events: none;
+      user-select: none;
+    }
+
+    &:before {
+      content: attr(data-before);
       font-weight: 500;
+    }
+    &:after {
+      content: attr(data-after);
     }
   }
 

--- a/projects/ui-framework/src/lib/tests/placeholders.service.spec.ts
+++ b/projects/ui-framework/src/lib/tests/placeholders.service.spec.ts
@@ -78,11 +78,9 @@ describe('PlachholderRteConverterService', () => {
       );
 
       expect(converted).toContain(
-        'data-placeholder-id="work' + separator + 'title">'
+        'data-placeholder-id="work' + separator + 'title"'
       );
-      expect(converted).toContain(
-        '{{&nbsp;</em><strong>Work</strong><em>&nbsp;-&nbsp;</em>Title<em>&nbsp;}}'
-      );
+      expect(converted).toContain('data-before="Work" data-after=" - Title"');
     });
   });
 
@@ -93,17 +91,15 @@ describe('PlachholderRteConverterService', () => {
       expect(converted).not.toContain('{{root' + separator + 'firstName}}');
       expect(converted).not.toContain('{{work' + separator + 'title}}');
       expect(converted).toContain(
-        // tslint:disable-next-line: max-line-length
-        'data-placeholder-id="root' +
-          separator +
-          'firstName"><em>{{&nbsp;</em><strong>Basic</strong><em>&nbsp;-&nbsp;</em>First name<em>&nbsp;}}'
+        'data-placeholder-id="root' + separator + 'firstName"'
       );
       expect(converted).toContain(
-        // tslint:disable-next-line: max-line-length
-        'data-placeholder-id="work' +
-          separator +
-          'title"><em>{{&nbsp;</em><strong>Work</strong><em>&nbsp;-&nbsp;</em>Title<em>&nbsp;}}'
+        'data-before="Basic" data-after=" - First name"'
       );
+      expect(converted).toContain(
+        'data-placeholder-id="work' + separator + 'title"'
+      );
+      expect(converted).toContain('data-before="Work" data-after=" - Title"');
     });
   });
 


### PR DESCRIPTION
- placeholders are now 1 character for char counter - addresses https://github.com/hibobio/hibob/issues/32156
- better Copy handler (Ctrl-С with empty selection resulted in js error previously - Froala bug; in some cases copied html contained all element, not only selected part)
- z-index placeholders insert button issue - addresses https://github.com/hibobio/hibob/issues/32155