### PR TITLE
Pavel/form elements - readonly & stories update

### DIFF
--- a/projects/ui-framework/src/lib/form-elements/checkbox/checkbox.component.html
+++ b/projects/ui-framework/src/lib/form-elements/checkbox/checkbox.component.html
@@ -12,10 +12,13 @@
        [attr.name]="id"
        [checked]="value === true"
        [required]="required"
-       [disabled]="disabled"
+       [disabled]="disabled || readonly"
+       [readonly]="readonly"
        (change)="toggleCheckbox()" />
 <label class="bchk-label"
-       [ngClass]="{'empty-label': !placeholder && !label}"
+       [ngClass]="{
+         'empty-label': !placeholder && !label
+        }"
        [attr.for]="id">
   {{ placeholder || label }}
 </label>

--- a/projects/ui-framework/src/lib/form-elements/checkbox/checkbox.component.scss
+++ b/projects/ui-framework/src/lib/form-elements/checkbox/checkbox.component.scss
@@ -51,3 +51,15 @@
     pointer-events: none;
   }
 }
+
+[readonly] + .bchk-label {
+  &:before {
+    pointer-events: none;
+  }
+  &:hover,
+  &:focus {
+    &:before {
+      box-shadow: none;
+    }
+  }
+}

--- a/projects/ui-framework/src/lib/form-elements/checkbox/checkbox.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/checkbox/checkbox.stories.ts
@@ -11,6 +11,8 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CheckboxModule } from './checkbox.module';
 import { StoryBookLayoutModule } from '../../story-book-layout/story-book-layout.module';
 
+import formElemsPropsDoc from '../form-elements.properties.md';
+
 const story = storiesOf(ComponentGroupType.FormElements, module).addDecorator(
   withKnobs
 );
@@ -23,6 +25,7 @@ const template = `
             [indeterminate]="indeterminate"
             [disabled]="disabled"
             [required]="required"
+            [readonly]="readonly"
             [hintMessage]="hintMessage"
             [warnMessage]="warnMessage"
             [errorMessage]="errorMessage">
@@ -40,23 +43,19 @@ const note = `
   #### Module
   *CheckboxModule* or *FormElementsModule*
 
+  ~~~
+  ${template}
+  ~~~
+
   #### Properties
   Name | Type | Description
   --- | --- | ---
   [value] | boolean | start checkbox state
-  [label] | string | label text (above input)
-  [placeholder] | string | placeholder text (next to input)
-  [disabled] | boolean | is field disabled
-  [required] | boolean | is field required
   [indeterminate] | boolean | indeterminate state
-  [hintMessage] | string | hint text
-  [warnMessage] | string | warning text
-  [errorMessage] | string | error text
   (checkboxChange) | EventEmitter<wbr>&lt;InputEvent&gt; | checkboxChange emitter
 
-  ~~~
-  ${template}
-  ~~~
+  ${formElemsPropsDoc}
+
 `;
 story.add(
   'Checkbox',
@@ -71,6 +70,7 @@ story.add(
         indeterminate: boolean('indeterminate', false),
         disabled: boolean('disabled', false),
         required: boolean('required', false),
+        readonly: boolean('readonly', false),
         hintMessage: text('hintMessage', 'Usefull hint'),
         warnMessage: text('warnMessage', ''),
         errorMessage: text('errorMessage', ''),

--- a/projects/ui-framework/src/lib/form-elements/date-picker/date-range-picker/date-range-picker.component.html
+++ b/projects/ui-framework/src/lib/form-elements/date-picker/date-range-picker/date-range-picker.component.html
@@ -18,10 +18,11 @@
 
   <div class="bfe-wrap start-date-wrap"
        [ngClass]="{
-              focused: inputFocused[0],
-              'has-suffix': !isInputEmpty(0),
+              focused: inputFocused[0] && !readonly,
+              'has-suffix': !isInputEmpty(0) && !readonly,
               'panel-above': panelPosition === panelPos.above,
-              'panel-below': panelPosition === panelPos.below
+              'panel-below': panelPosition === panelPos.below,
+              readonly: readonly
        }">
 
     <input #input
@@ -32,14 +33,14 @@
            [max]="value?.endDate || maxDate || null"
            [setTo]="type === types.month ? dateAdjust.startOfMonth : null"
            (parsed)="onInputChange($event,0)"
-           [readonly]="!allowKeyInput"
+           [readonly]="!allowKeyInput || readonly"
            autocomplete="off"
            [attr.id]="idSD"
            [attr.name]="idSD"
            [type]="inputTypes.text"
            [attr.placeholder]="hideLabelOnFocus && (startDateLabel || label) ? (!required ? (startDateLabel || label) :
            (startDateLabel || label) + '*') : !hideLabelOnFocus && label && startDateLabel ? startDateLabel : placeholder"
-           [disabled]="disabled"
+           [disabled]="disabled || readonly"
            [required]="required"
            (click)="openPicker(0)"
            (focus)="onInputFocus(0)"
@@ -52,13 +53,13 @@
            readonly
            tabindex="-1"
            aria-hidden="true"
-           [disabled]="disabled"
+           [disabled]="disabled || readonly"
            [matDatepicker]="startDatePicker"
            (dateChange)="transmit($event.value, 'value.startDate')"
            [min]="minDate || null"
            [max]="value?.endDate || maxDate || null">
 
-    <span [hidden]="isInputEmpty(0)"
+    <span [hidden]="isInputEmpty(0) || readonly"
           class="bfe-suffix">
       <b-icon class="clear-input"
               role="button"
@@ -73,10 +74,11 @@
 
   <div class="bfe-wrap end-date-wrap"
        [ngClass]="{
-              focused: inputFocused[1],
-              'has-suffix': !isInputEmpty(1),
+              focused: inputFocused[1] && !readonly,
+              'has-suffix': !isInputEmpty(1) && !readonly,
               'panel-above': panelPosition === panelPos.above,
-              'panel-below': panelPosition === panelPos.below
+              'panel-below': panelPosition === panelPos.below,
+              readonly: readonly
        }">
 
     <input #input
@@ -87,7 +89,7 @@
            [max]="maxDate || null"
            [setTo]="type === types.month ? dateAdjust.endOfMonth : null"
            (parsed)="onInputChange($event,1)"
-           [readonly]="!allowKeyInput"
+           [readonly]="!allowKeyInput || readonly"
            autocomplete="off"
            [attr.id]="idED"
            [attr.name]="idED"
@@ -95,7 +97,7 @@
            [attr.placeholder]="hideLabelOnFocus && (endDateLabel || label) ? (!required ? ((label && null) ||
            endDateLabel) : ((label && ' ') || endDateLabel + '*')) :
            !hideLabelOnFocus && label && endDateLabel ? endDateLabel : placeholder"
-           [disabled]="disabled"
+           [disabled]="disabled || readonly"
            [required]="required"
            (click)="openPicker(1)"
            (focus)="onInputFocus(1)"
@@ -108,13 +110,13 @@
            readonly
            tabindex="-1"
            aria-hidden="true"
-           [disabled]="disabled"
+           [disabled]="disabled || readonly"
            [matDatepicker]="endDatePicker"
            (dateChange)="transmit($event.value, 'value.endDate')"
            [min]="value?.startDate || minDate || null"
            [max]="maxDate || null">
 
-    <span [hidden]="isInputEmpty(1)"
+    <span [hidden]="isInputEmpty(1) || readonly"
           class="bfe-suffix">
       <b-icon class="clear-input"
               role="button"
@@ -130,7 +132,7 @@
 
 <mat-datepicker #startDatePicker
                 [startView]="type === types.month ? 'year' : 'month'"
-                [disabled]="disabled"
+                [disabled]="disabled || readonly"
                 [touchUi]="isMobile"
                 [panelClass]="'b-datepicker-panel start-date-picker type-' + type + (panelClass ? ' ' + panelClass :
                 '')"
@@ -141,7 +143,7 @@
 </mat-datepicker>
 <mat-datepicker #endDatePicker
                 [startView]="type === types.month ? 'year' : 'month'"
-                [disabled]="disabled"
+                [disabled]="disabled || readonly"
                 [touchUi]="isMobile"
                 [panelClass]="'b-datepicker-panel end-date-picker type-' + type + (panelClass ? ' ' + panelClass : '')"
                 [dateClass]="getDateClass"

--- a/projects/ui-framework/src/lib/form-elements/date-picker/date-range-picker/date-range-picker.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/date-picker/date-range-picker/date-range-picker.stories.ts
@@ -15,6 +15,10 @@ import { thisMonth, thisYear } from '../../../services/utils/functional-utils';
 import { DatepickerType } from '../datepicker.enum';
 import { BDateAdapterMock, UserLocaleServiceMock } from '../dateadapter.mock';
 
+import formElemsPropsDoc from '../../form-elements.properties.md';
+import datepickerPropsDoc from '../datepicker.properties.md';
+import datepickerInterfaceDoc from '../datepicker.interface.md';
+
 const story = storiesOf(ComponentGroupType.FormElements, module).addDecorator(
   withKnobs
 );
@@ -34,8 +38,9 @@ const template = `
               [errorMessage]="errorMessage"
               [disabled]="disabled"
               [required]="required"
+              [readonly]="readonly"
               (dateChange)="dateChange($event)">
-</b-date-range-picker>
+              </b-date-range-picker>
 `;
 
 const storyTemplate = `
@@ -52,38 +57,31 @@ const note = `
   #### Module
   *DateRangePickerModule*
 
-  #### Properties
-
-  Name | Type | Description | Default value
-  --- | --- | --- | ---
-  [type] | DatepickerType | date or month picker | date
-  [value] | DateRangePickerValue <br> ({from: Date / string (YYYY-MM-DD),\
-     <br>to: Date / string (YYYY-MM-DD)} | start and end dates | &nbsp;
-  [minDate] | Date / string (YYYY-MM-DD) | minimum date | &nbsp;
-  [maxDate] | Date / string (YYYY-MM-DD) | maximum date | &nbsp;
-  [label] | string | label text (above input) | &nbsp;
-  [startDateLabel] | string | first datepicker label | &nbsp;
-  [endDateLabel] | string | second datepicker label | &nbsp;
-  [placeholder] | string | placeholder text (inside input) | &nbsp;
-  [dateFormat] | string | string, representing date format (will also be used as default placeholder) | &nbsp;
-  [hideLabelOnFocus] | boolean | places label in placeholder position | false
-  [disabled] | boolean | is field disabled | false
-  [required] | boolean | is field required | false
-  [hintMessage] | string | hint text | &nbsp;
-  [warnMessage] | string | warning text | &nbsp;
-  [errorMessage] | string | error text | &nbsp;
-  (dateChange) | EventEmitter<wbr>&lt;InputEvent&gt; | Emited on date change | &nbsp;
-
-  #### Notes
-
-  - In \`[type]="'month'"\` mode, the output start date \`.from\` will be\
-   1st of month, and the end date \`.to\` will be the last day of month (28-31).
-  - the output event object also contains \`.date\` property that contains
-   \`.startDate\` and \`.endDate\` as Date objects.
+  **Note:** When importing DateRangePickerModule, you have to initialize it with <u>DateAdapter</u>:
+  \`\`\`
+  imports: [
+    DateRangePickerModule.init(UserLocaleDateAdapter)
+  ]
+  \`\`\`
 
   ~~~
   ${template}
   ~~~
+
+  #### Properties
+
+  Name | Type | Description
+  --- | --- | ---
+  [value] | DateRangePickerValue <br> ({from: Date / string (YYYY-MM-DD),\
+     <br>to: Date / string (YYYY-MM-DD)} | start and end dates
+  [startDateLabel] | string | first datepicker label
+  [endDateLabel] | string | second datepicker label
+
+  ${datepickerPropsDoc}
+
+  ${formElemsPropsDoc}
+
+  ${datepickerInterfaceDoc}
 `;
 
 const mockValues = [
@@ -137,6 +135,7 @@ story.add(
         hideLabelOnFocus: boolean('hideLabelOnFocus', false),
         disabled: boolean('disabled', false),
         required: boolean('required', false),
+        readonly: boolean('readonly', false),
         hintMessage: text('hintMessage', 'This field should contain something'),
         warnMessage: text('warnMessage', ''),
         errorMessage: text('errorMessage', ''),

--- a/projects/ui-framework/src/lib/form-elements/date-picker/dateadapter.mock.ts
+++ b/projects/ui-framework/src/lib/form-elements/date-picker/dateadapter.mock.ts
@@ -9,7 +9,7 @@ import {
 import { get } from 'lodash';
 import { format, parseISO } from 'date-fns';
 import { DateParseService } from './date-parse-service/date-parse.service';
-import { FormatParserResult } from './datepicker.interface';
+import { FormatParserResult, BDateAdapter } from './datepicker.interface';
 
 const mockUser: {
   dateFormat: DateLocaleFormatKeys;
@@ -34,9 +34,7 @@ export const UserLocaleServiceMock = {
 
     if (dateFormat === undefined) {
       throw new Error(
-        `${
-          UserLocaleServiceMock.dateFormat
-        } is not a valid User Locale date format.`
+        `${UserLocaleServiceMock.dateFormat} is not a valid User Locale date format.`
       );
     }
 
@@ -50,7 +48,8 @@ export const UserLocaleServiceMock = {
 @Injectable({
   providedIn: 'root',
 })
-export class BDateAdapterMock extends NativeDateAdapter {
+export class BDateAdapterMock extends NativeDateAdapter
+  implements BDateAdapter {
   public static readonly formatMonthYearLabel = 'MMM yyyy';
 
   public static readonly formatFullDate: FormatParserResult = DateParseService.prototype.parseFormat(

--- a/projects/ui-framework/src/lib/form-elements/date-picker/datepicker.abstract.ts
+++ b/projects/ui-framework/src/lib/form-elements/date-picker/datepicker.abstract.ts
@@ -139,7 +139,7 @@ export abstract class BaseDatepickerElement extends BaseFormElement
   private doneFirstChange = false;
   private useFormatForPlaceholder = false;
 
-  protected doOnPickerOpen(picker: MatDatepicker<any>): void { }
+  protected doOnPickerOpen(picker: MatDatepicker<any>): void {}
 
   ngOnInit(): void {
     this.resizeSubscription = fromEvent(this.windowRef.nativeWindow, 'resize')
@@ -244,6 +244,10 @@ export abstract class BaseDatepickerElement extends BaseFormElement
     ) {
       this.placeholder = this.dateFormats[this.type].format.toLowerCase();
       this.useFormatForPlaceholder = true;
+    }
+
+    if (hasChanges(changes, ['readonly'])) {
+      this.inputFocused = this.inputFocused.map(() => false);
     }
 
     this.doneFirstChange = true;

--- a/projects/ui-framework/src/lib/form-elements/date-picker/datepicker.interface.md
+++ b/projects/ui-framework/src/lib/form-elements/date-picker/datepicker.interface.md
@@ -1,0 +1,6 @@
+
+#### interface: DateRangePickerValue
+Name | Type | Description
+--- | --- | ---
+from | string (YYYY-MM-DD) | start date
+to | string (YYYY-MM-DD) | end date

--- a/projects/ui-framework/src/lib/form-elements/date-picker/datepicker.interface.ts
+++ b/projects/ui-framework/src/lib/form-elements/date-picker/datepicker.interface.ts
@@ -1,4 +1,4 @@
-import { DateFormat } from '../../types';
+import { DateFormat, LocaleFormat, DateLocaleFormatKeys } from '../../types';
 
 export interface DateRangePickerValue {
   from: string;
@@ -34,4 +34,15 @@ export interface DateParseResult {
   format: DateFormat;
   value: string;
   date: Date;
+}
+
+export interface BDateAdapter {
+  getFormat: (displayFormat: LocaleFormat) => FormatParserResult;
+  getLocaleFormat: (
+    key: DateLocaleFormatKeys,
+    frmt: LocaleFormat
+  ) => DateFormat;
+  parse: (value: any) => Date | null;
+  format: (date: Date, displayFormat: string) => string;
+  getFirstDayOfWeek: () => number;
 }

--- a/projects/ui-framework/src/lib/form-elements/date-picker/datepicker.properties.md
+++ b/projects/ui-framework/src/lib/form-elements/date-picker/datepicker.properties.md
@@ -1,0 +1,13 @@
+#### Datepicker/DateRangePicker common properties
+Name | Type | Description | Default
+--- | --- | --- | ---
+[type] | DatepickerType | date or month picker | date
+[dateFormat] | string | string, representing date format (will also be used as default placeholder) | &nbsp;
+[minDate] | Date / string (YYYY-MM-DD) | minimum date | &nbsp;
+[maxDate] | Date / string (YYYY-MM-DD) | maximum date | &nbsp;
+(dateChange) | EventEmitter<wbr>&lt;InputEvent&gt; |  Emited on date change | &nbsp;
+
+#### Notes
+
+- In \`[type]="'month'"\` mode, the output date will be 1st of month, and the end date \`.to\` (in case of DateRangePicker) will be the last day of month (28-31).
+- the output event object also contains \`.date\` property that contains value as Date object (in case of DateRangePicker it contains  \`.startDate\` and \`.endDate\` as Date objects).

--- a/projects/ui-framework/src/lib/form-elements/date-picker/datepicker/datepicker.component.html
+++ b/projects/ui-framework/src/lib/form-elements/date-picker/datepicker/datepicker.component.html
@@ -8,10 +8,11 @@
 <div class="bfe-wrap has-prefix has-suffix"
      #inputWrap
      [ngClass]="{
-        focused: inputFocused[0],
-        'has-suffix': !isInputEmpty(),
+        focused: inputFocused[0] && !readonly,
+        'has-suffix': !isInputEmpty() && !readonly,
         'panel-above': panelPosition === panelPos.above,
-        'panel-below': panelPosition === panelPos.below
+        'panel-below': panelPosition === panelPos.below,
+        readonly: readonly
      }"
      (click.outside-zone)="input.focus()">
 
@@ -29,13 +30,13 @@
          [max]="maxDate || null"
          [setTo]="type === types.month ? dateAdjust.startOfMonth : null"
          (parsed)="onInputChange($event)"
-         [readonly]="!allowKeyInput"
+         [readonly]="!allowKeyInput || readonly"
          autocomplete="off"
          [attr.id]="id"
          [attr.name]="id"
          [type]="inputTypes.text"
          [attr.placeholder]="hideLabelOnFocus && label ? (!required ? label : label + '*') : placeholder"
-         [disabled]="disabled"
+         [disabled]="disabled || readonly"
          [required]="required"
          (click)="$event.stopPropagation(); openPicker()"
          (focus)="onInputFocus()"
@@ -48,13 +49,13 @@
          readonly
          tabindex="-1"
          aria-hidden="true"
-         [disabled]="disabled"
+         [disabled]="disabled || readonly"
          [matDatepicker]="picker"
          (dateChange)="transmit($event.value)"
          [min]="minDate || null"
          [max]="maxDate || null">
 
-  <span [hidden]="isInputEmpty()"
+  <span [hidden]="isInputEmpty() || readonly"
         class="bfe-suffix">
     <b-icon class="clear-input"
             role="button"
@@ -70,7 +71,7 @@
 
 <mat-datepicker #picker
                 [startView]="type === types.month ? 'year' : 'month'"
-                [disabled]="disabled"
+                [disabled]="disabled || readonly"
                 [touchUi]="isMobile"
                 [panelClass]="'b-datepicker-panel ' + ' type-' + type + (panelClass ? ' ' + panelClass : '')"
                 (opened)="onPickerOpen()"

--- a/projects/ui-framework/src/lib/form-elements/date-picker/datepicker/datepicker.component.scss
+++ b/projects/ui-framework/src/lib/form-elements/date-picker/datepicker/datepicker.component.scss
@@ -42,7 +42,7 @@
   cursor: default;
 
   .bfe-input {
-    pointer-events: none;
+    cursor: default;
   }
 }
 

--- a/projects/ui-framework/src/lib/form-elements/date-picker/datepicker/datepicker.component.scss
+++ b/projects/ui-framework/src/lib/form-elements/date-picker/datepicker/datepicker.component.scss
@@ -1,9 +1,5 @@
 @import '../../../style/common-imports';
 
-:host .bfe-input[readonly] {
-  cursor: pointer;
-}
-
 .bfe-wrap {
   position: relative;
 }
@@ -35,6 +31,18 @@
   &.panel-below {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
+  }
+}
+
+:host .bfe-input[readonly] {
+  cursor: pointer;
+}
+
+.bfe-wrap.readonly {
+  cursor: default;
+
+  .bfe-input {
+    pointer-events: none;
   }
 }
 

--- a/projects/ui-framework/src/lib/form-elements/date-picker/datepicker/datepicker.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/date-picker/datepicker/datepicker.stories.ts
@@ -16,6 +16,9 @@ import { DatepickerType } from '../datepicker.enum';
 import { mockText } from '../../../mock.const';
 import { BDateAdapterMock, UserLocaleServiceMock } from '../dateadapter.mock';
 
+import formElemsPropsDoc from '../../form-elements.properties.md';
+import datepickerPropsDoc from '../datepicker.properties.md';
+
 const story = storiesOf(ComponentGroupType.FormElements, module).addDecorator(
   withKnobs
 );
@@ -34,6 +37,7 @@ const template = `
               [errorMessage]="errorMessage"
               [disabled]="disabled"
               [required]="required"
+              [readonly]="readonly"
               (dateChange)="dateChange($event)">
 </b-datepicker>
 `;
@@ -52,34 +56,26 @@ const note = `
   #### Module
   *DatepickerModule*
 
-  #### Properties
-
-  Name | Type | Description | Default value
-  --- | --- | --- | ---
-  [type] | DatepickerType | date or month picker | date
-  [value] | Date / string (YYYY-MM-DD) | date | &nbsp;
-  [minDate] | Date / string (YYYY-MM-DD) | minimum date | &nbsp;
-  [maxDate] | Date / string (YYYY-MM-DD) | maximum date | &nbsp;
-  [label] | string | label text (above input) | &nbsp;
-  [description] | string | description text (above icon) | &nbsp;
-  [placeholder] | string | placeholder text (inside input) | &nbsp;
-  [dateFormat] | string | string, representing date format (will also be used as default placeholder) | &nbsp;
-  [hideLabelOnFocus] | boolean | places label in placeholder position | false
-  [disabled] | boolean | is field disabled | false
-  [required] | boolean | is field required | false
-  [hintMessage] | string | hint text | &nbsp;
-  [warnMessage] | string | warning text | &nbsp;
-  [errorMessage] | string | error text | &nbsp;
-  (dateChange) | EventEmitter<wbr>&lt;InputEvent&gt; |  Emited on date change | &nbsp;
-
-  #### Notes
-
-  - In \`[type]="'month'"\` mode, the output date will be 1st of month.
-  - the output event object also contains \`.date\` property that contains value as Date object.
+  **Note:** When importing DateRangePickerModule, you have to initialize it with <u>DateAdapter</u>:
+  \`\`\`
+  imports: [
+    DatepickerModule.init(UserLocaleDateAdapter)
+  ]
+  \`\`\`
 
   ~~~
   ${template}
   ~~~
+
+  #### Properties
+
+  Name | Type | Description
+  --- | --- | ---
+  [value] | Date / string (YYYY-MM-DD) | date
+
+  ${datepickerPropsDoc}
+
+  ${formElemsPropsDoc}
 `;
 
 story.add(
@@ -133,6 +129,7 @@ story.add(
         hideLabelOnFocus: boolean('hideLabelOnFocus', false),
         disabled: boolean('disabled', false),
         required: boolean('required', false),
+        readonly: boolean('readonly', false),
         hintMessage: text('hintMessage', 'This field should contain something'),
         warnMessage: text('warnMessage', ''),
         errorMessage: text('errorMessage', ''),

--- a/projects/ui-framework/src/lib/form-elements/form-elements.properties.md
+++ b/projects/ui-framework/src/lib/form-elements/form-elements.properties.md
@@ -1,8 +1,8 @@
 #### Form Elements common properties
 Name | Type | Description | Default
 --- | --- | --- | ---
-[label] | string | label text | &nbsp;
-[placeholder] | string | placeholder text | &nbsp;
+[label] | string | label text (above input)| &nbsp;
+[placeholder] | string | placeholder text (inside input) | &nbsp;
 [hideLabelOnFocus] | boolean | if true, label text (if present) will be used as placeholder (there will be no label above input) | false
 [description] | string | description text (above <i>i</i> icon) | &nbsp;
 [hintMessage] | string | hint text | &nbsp;

--- a/projects/ui-framework/src/lib/form-elements/form-elements.properties.md
+++ b/projects/ui-framework/src/lib/form-elements/form-elements.properties.md
@@ -1,0 +1,20 @@
+#### Form Elements common properties
+Name | Type | Description | Default
+--- | --- | --- | ---
+[label] | string | label text | &nbsp;
+[placeholder] | string | placeholder text | &nbsp;
+[hideLabelOnFocus] | boolean | if true, label text (if present) will be used as placeholder (there will be no label above input) | false
+[description] | string | description text (above <i>i</i> icon) | &nbsp;
+[hintMessage] | string | hint text | &nbsp;
+[warnMessage] | string | hint text | &nbsp;
+[errorMessage] | string | error text | &nbsp;
+&nbsp; | &nbsp; | &nbsp; | &nbsp;
+[disabled] | boolean | is field disabled | false
+[required] | boolean | is field required | false
+[readonly] | boolean | if true, will not emit events and not allow any changes | false
+
+#### Form Elements common methods
+Name | Description
+--- | ---
+focus() | will focus the input
+

--- a/projects/ui-framework/src/lib/form-elements/input.properties.md
+++ b/projects/ui-framework/src/lib/form-elements/input.properties.md
@@ -1,0 +1,9 @@
+#### Input-type elements common properties
+Name | Type | Description | Default
+--- | --- | --- | ---
+[value] | string/number | value of input field | &nbsp;
+[minChars] | number | minimum length | &nbsp;
+[maxChars] | number | maximum length.<br> *Note:* It might not make sense to provide minChars/maxChars for number-type inputs, but if you do, the input will be limited by number of digits.  | &nbsp;
+[showCharCounter] | boolean | set to false to hide character counter | true
+[enableBrowserAutoComplete] | InputAutoCompleteOptions | turn on/off browser autocomplete | off
+(inputEvents) | EventEmitter<wbr>&lt;InputEvent&gt; | input events emitter | &nbsp;

--- a/projects/ui-framework/src/lib/form-elements/input/input.component.html
+++ b/projects/ui-framework/src/lib/form-elements/input/input.component.html
@@ -26,7 +26,7 @@
          [attr.placeholder]="hideLabelOnFocus && label ? (!required ? label : label + '*') : placeholder"
          [value]="value"
          [autocomplete]="enableBrowserAutoComplete"
-         [disabled]="disabled"
+         [disabled]="disabled || readonly"
          [required]="required"
          [readonly]="readonly"
          [attr.minlength]="minChars || null"
@@ -47,12 +47,12 @@
     <button type="button"
             class="step-button b-icon-chevron-up b-icon-large has-hover"
             [ngClass]="{ 'b-icon-normal': !inputFocused }"
-            [disabled]="disabled || value >= max"
+            [disabled]="disabled || readonly || value >= max"
             (click)="onIncrement()"></button>
     <button type="button"
             class="step-button b-icon-chevron-down b-icon-large has-hover"
             [ngClass]="{ 'b-icon-normal': !inputFocused }"
-            [disabled]="disabled || value <= min"
+            [disabled]="disabled || readonly || value <= min"
             (click)="onDecrement()"></button>
   </div>
 

--- a/projects/ui-framework/src/lib/form-elements/input/input.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/input/input.stories.ts
@@ -15,6 +15,9 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { StoryBookLayoutModule } from '../../story-book-layout/story-book-layout.module';
 import { mockText } from '../../mock.const';
 
+import formElemsPropsDoc from '../form-elements.properties.md';
+import inputElemsPropsDoc from '../input.properties.md';
+
 const story = storiesOf(ComponentGroupType.FormElements, module).addDecorator(
   withKnobs
 );
@@ -59,21 +62,14 @@ const note = `
   #### Module
   *InputModule* or *FormElementsModule*
 
+  ~~~
+  ${template}
+  ~~~
+
   #### Properties
   Name | Type | Description | Default
   --- | --- | --- | ---
   [inputType] | InputTypes | type of input field | text
-  [value] | string/number | value of input field | &nbsp;
-  [label] | string | label text (above input) | &nbsp;
-  [description] | string | description text (above icon) | &nbsp;
-  [placeholder] | string | placeholder text (inside input) | &nbsp;
-  [hideLabelOnFocus] | boolean | if true: there will be no label above\
-   input, label text (if present) will be used as placeholder | false
-  [minChars] | number | minimum length | &nbsp;
-  [maxChars] | number | maximum length.<br> \
-  *Note:* It might not make sense to provide minChars/maxChars for number-type inputs, but if you do, \
-  the input will be limited by number of digits.  | &nbsp;
-  [showCharCounter] | boolean | set to false to hide character counter | true
   [min] | number | (only relevant for number inputs) minimum value (value will be corrected on blur). \
   *Note*: Defaults to 0, so negative numbers are discarded. \
   Set to null, undefined or some negative value to allow negative numbers | <u>0</u>
@@ -82,18 +78,10 @@ const note = `
    Buttons will not be displayed, if step value is not provided.<br> \
    *Note:* When using the step buttons, the number value will be rounded to the decimal places \
    of the step (if step is 3, value of 5.5 + 3 will be rounded to 9). | &nbsp;
-  [readonly] | boolean | disables input | false
-  [disabled] | boolean | is field disabled | false
-  [required] | boolean | is field required | false
-  [hintMessage] | string | hint text | &nbsp;
-  [warnMessage] | string | warning text | &nbsp;
-  [errorMessage] | string | error text | &nbsp;
-  [enableBrowserAutoComplete] | InputAutoCompleteOptions | shows browser autocomplete options | off
-  (inputEvents) | EventEmitter<wbr>&lt;InputEvent&gt; | input events emitter | &nbsp;
 
-  ~~~
-  ${template}
-  ~~~
+  ${inputElemsPropsDoc}
+
+  ${formElemsPropsDoc}
 `;
 story.add(
   'Input',

--- a/projects/ui-framework/src/lib/form-elements/password-input/password-input.component.html
+++ b/projects/ui-framework/src/lib/form-elements/password-input/password-input.component.html
@@ -3,8 +3,10 @@
        [attr.for]="id">{{label}}</label>
 
 <div class="bfe-wrap has-suffix"
-     [ngClass]="{focused: inputFocused,
-      'has-suffix': !isInputEmpty()}">
+     [ngClass]="{
+       focused: inputFocused,
+      'has-suffix': !isInputEmpty()
+      }">
 
   <input #input
          class="bfe-input"
@@ -15,7 +17,7 @@
          [attr.placeholder]="hideLabelOnFocus && label ? (!required ? label : label + '*') : placeholder"
          [value]="value"
          [autocomplete]="enableBrowserAutoComplete"
-         [disabled]="disabled"
+         [disabled]="disabled || readonly"
          [required]="required"
          [readonly]="readonly"
          [attr.minlength]="minChars || null"

--- a/projects/ui-framework/src/lib/form-elements/password-input/password-input.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/password-input/password-input.stories.ts
@@ -2,7 +2,6 @@ import { storiesOf } from '@storybook/angular';
 import {
   boolean,
   number,
-  select,
   text,
   withKnobs,
 } from '@storybook/addon-knobs/angular';
@@ -16,6 +15,10 @@ import { StoryBookLayoutModule } from '../../story-book-layout/story-book-layout
 const story = storiesOf(ComponentGroupType.FormElements, module).addDecorator(
   withKnobs
 );
+
+import formElemsPropsDoc from '../form-elements.properties.md';
+import inputElemsPropsDoc from '../input.properties.md';
+
 const template = `
 <b-password-input
               [value]="value"
@@ -46,28 +49,19 @@ const storyTemplate = `
 const note = `
   ## Password Input
 
-  #### Properties
-
-  Name | Type | Description
-  --- | --- | --- | ---
-  [value] | string | value of input field
-  [label] | string | label text (above input)
-  [placeholder] | string | placeholder text (inside input)
-  [minChars] | number | min length
-  [maxChars] | number | max length
-  [readonly] | boolean | disables input
-  [disabled] | boolean | is field disabled
-  [required] | boolean | is field required
-  [hintMessage] | string | hint text
-  [warnMessage] | string | warning text
-  [errorMessage] | string | error text
-  [hideLabelOnFocus] | boolean | if true: there will be no label above\
-   input, label text (if present) will be used as placeholder
-  [enableBrowserAutoComplete] | InputAutoCompleteOptions | shows browser autocomplete options
-  (inputEvents) | EventEmitter<wbr>&lt;InputEvent&gt; | input events emitter
   ~~~
   ${template}
   ~~~
+
+  #### Properties
+  Name | Type | Description
+  --- | --- | --- | ---
+  [value] | string | value of input field
+
+  ${inputElemsPropsDoc}
+
+  ${formElemsPropsDoc}
+
 `;
 
 story.add(

--- a/projects/ui-framework/src/lib/form-elements/radio-button/radio-button.component.html
+++ b/projects/ui-framework/src/lib/form-elements/radio-button/radio-button.component.html
@@ -15,7 +15,8 @@
            [value]="radio[key]"
            [checked]="(value && value[key] === radio[key]) || value == radio[key]"
            [required]="required"
-           [disabled]="disabled"
+           [readonly]="readonly"
+           [disabled]="disabled || readonly"
            (change)="onRadioChange(radio[key])" />
     <label class="brd-label"
            [attr.for]="id+'-'+i">{{radio.label || radio[key] || radio}}</label>

--- a/projects/ui-framework/src/lib/form-elements/radio-button/radio-button.component.scss
+++ b/projects/ui-framework/src/lib/form-elements/radio-button/radio-button.component.scss
@@ -67,3 +67,10 @@
     pointer-events: none;
   }
 }
+
+[readonly] + .brd-label {
+  &,
+  &:before {
+    pointer-events: none;
+  }
+}

--- a/projects/ui-framework/src/lib/form-elements/radio-button/radio-button.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/radio-button/radio-button.stories.ts
@@ -1,6 +1,5 @@
 import { storiesOf } from '@storybook/angular';
 import {
-  array,
   boolean,
   select,
   text,
@@ -15,6 +14,8 @@ import values from 'lodash/values';
 import { StoryBookLayoutModule } from '../../story-book-layout/story-book-layout.module';
 import { RadioDirection } from './radio-button.enum';
 
+import formElemsPropsDoc from '../form-elements.properties.md';
+
 const direction = values(RadioDirection);
 const story = storiesOf(ComponentGroupType.FormElements, module).addDecorator(
   withKnobs
@@ -27,6 +28,7 @@ const template = `
                 [direction]="direction"
                 [disabled]="disabled"
                 [required]="required"
+                [readonly]="readonly"
                 [hintMessage]="hintMessage"
                 [warnMessage]="warnMessage"
                 [errorMessage]="errorMessage"
@@ -44,24 +46,20 @@ const note = `
   #### Module
   *RadioButtonModule*
 
-  #### Properties
+  ~~~
+  ${template}
+  ~~~
 
+  #### Properties
   Name | Type | Description
   --- | --- | ---
   [radioConfig] | RadioConfig[] | list of RadioConfig ({id, label}) objects
   [value] | RadioConfig | selected option
   [direction] | RadioDirection | column or row, default=row
-  [label] | string | label text
-  [hintMessage] | string | hint text
-  [warnMessage] | string | warning text
-  [errorMessage] | string | error text
-  [disabled] | boolean | is field disabled
-  [required] | boolean | is field required
   (radioChange) | EventEmitter<wbr>&lt;string/number&gt; | fired on radio change, returns option ID
 
-  ~~~
-  ${template}
-  ~~~
+  ${formElemsPropsDoc}
+
 `;
 
 story.add(
@@ -76,6 +74,7 @@ story.add(
         label: text('label', 'Radio label'),
         required: boolean('required', false),
         disabled: boolean('disabled', false),
+        readonly: boolean('readonly', false),
 
         hintMessage: text('hintMessage', 'Useful hint'),
         warnMessage: text('warnMessage', ''),

--- a/projects/ui-framework/src/lib/form-elements/social/social.component.html
+++ b/projects/ui-framework/src/lib/form-elements/social/social.component.html
@@ -19,6 +19,7 @@
          [errorMessage]="errorMessage"
          [disabled]="disabled"
          [required]="required"
+         [readonly]="readonly"
          [maxChars]="50"
          [showCharCounter]="false"
          (inputEvents)="onInputEvents($event)"

--- a/projects/ui-framework/src/lib/form-elements/social/social.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/social/social.stories.ts
@@ -13,6 +13,8 @@ import { SocialModule } from './social.module';
 import { SearchModule } from '../../search/search/search.module';
 import { Social } from './social.enum';
 
+import formElemsPropsDoc from '../form-elements.properties.md';
+
 const story = storiesOf(ComponentGroupType.FormElements, module).addDecorator(
   withKnobs
 );
@@ -24,6 +26,7 @@ const template = `
           [placeholder]="placeholder"
           [disabled]="disabled"
           [required]="required"
+          [readonly]="readonly"
           [hintMessage]="hintMessage"
           [warnMessage]="warnMessage"
           [errorMessage]="errorMessage"
@@ -45,6 +48,10 @@ const note = `
   #### Module
   *SocialModule*
 
+  ~~~
+  ${template}
+  ~~~
+
   #### Properties
   Name | Type | Description | Default value
   --- | --- | --- | ---
@@ -54,16 +61,10 @@ const note = `
   but if [label] is passed, it will be displayed instead, \
   and the Social icon will be placed in placeholder (inside input) | &nbsp;
   [placeholder] | string | placeholder text (inside input) | 'username'
-  [disabled] | boolean | is field disabled | false
-  [required] | boolean | is field required | false
-  [hintMessage] | string | hint text | &nbsp;
-  [warnMessage] | string | warning text | &nbsp;
-  [errorMessage] | string | error text | &nbsp;
   (socialInputChange) |  EventEmitter<wbr>&lt;InputEvent&gt; | input events emitter | &nbsp;
 
-  ~~~
-  ${template}
-  ~~~
+  ${formElemsPropsDoc}
+
 `;
 
 story.add(
@@ -81,6 +82,7 @@ story.add(
         errorMessage: text('errorMessage', ''),
         disabled: boolean('disabled', false),
         required: boolean('required', false),
+        readonly: boolean('readonly', false),
         socialInputChange: action('social'),
       },
       moduleMetadata: {

--- a/projects/ui-framework/src/lib/form-elements/split-input-single-select/split-input-single-select.component.html
+++ b/projects/ui-framework/src/lib/form-elements/split-input-single-select/split-input-single-select.component.html
@@ -8,6 +8,7 @@
          [hideLabelOnFocus]="hideLabelOnFocus"
          [required]="required"
          [disabled]="disabled"
+         [readonly]="readonly"
          [maxChars]="50"
          [showCharCounter]="false"
          [hintMessage]="hintMessage"
@@ -18,7 +19,9 @@
 
 <b-single-select (selectChange)="onSelectChange($event)"
                  [disabled]="disabled"
+                 [readonly]="readonly"
                  [options]="options"
                  [showSingleGroupHeader]="false"
+                 [panelClass]="'bsiss-panel'"
                  [doPropagate]="false">
 </b-single-select>

--- a/projects/ui-framework/src/lib/form-elements/split-input-single-select/split-input-single-select.component.scss
+++ b/projects/ui-framework/src/lib/form-elements/split-input-single-select/split-input-single-select.component.scss
@@ -46,6 +46,10 @@ b-single-select {
   }
 }
 
+::ng-deep .cdk-overlay-pane.b-select-panel.bsiss-panel {
+  min-width: 0;
+}
+
 :host {
   &.error {
     b-single-select::ng-deep .bfe-wrap {

--- a/projects/ui-framework/src/lib/form-elements/split-input-single-select/split-input-single-select.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/split-input-single-select/split-input-single-select.stories.ts
@@ -1,7 +1,6 @@
 import { storiesOf } from '@storybook/angular';
 import {
   boolean,
-  number,
   object,
   select,
   text,
@@ -18,6 +17,8 @@ import map from 'lodash/map';
 import { InputSingleSelectValue } from './split-input-single-select.interface';
 import { mockText } from '../../mock.const';
 
+import formElemsPropsDoc from '../form-elements.properties.md';
+
 const story = storiesOf(ComponentGroupType.FormElements, module).addDecorator(
   withKnobs
 );
@@ -32,6 +33,7 @@ const template = `
                              [errorMessage]="errorMessage"
                              [disabled]="disabled"
                              [required]="required"
+                             [readonly]="readonly"
                              (elementChange)="elementChange($event)">
 </b-split-input-single-select>
 `;
@@ -47,23 +49,19 @@ const storyTemplate = `
 const note = `
   ## Split input single select
 
-  #### Properties
+  ~~~
+  ${template}
+  ~~~
 
+  #### Properties
   Name | Type | Description
   --- | --- | ---
   [value] | SplitInputSingleSelectValue | value of the input and select
   [selectOptions] | SelectGroupOption[] | the options model for the select element
-  [label] | string | label text
-  [description] | string | description text (above icon)
-  [disabled] | boolean | is field disabled
-  [required] | boolean | is field required
-  [hintMessage] | text | hint text
-  [errorMessage] | text | error text
   (elementChange) | EventEmitter<wbr>&lt;InputSingleSelectValue&gt; |  change emitter
 
-  ~~~
-  ${template}
-  ~~~
+  ${formElemsPropsDoc}
+
 `;
 
 const currencies = [
@@ -143,16 +141,21 @@ story.add(
     return {
       template: storyTemplate,
       props: {
-        value: object('value', value),
-        inputType: select('type', InputTypes, InputTypes.number),
-        label: text('label', 'Base salary'),
-        description: text('description', mockText(30)),
-        disabled: boolean('disabled', false),
-        required: boolean('required', false),
-        hintMessage: text('hintMessage', 'This field should contain something'),
-        errorMessage: text('errorMessage', ''),
+        value: object('value', value, 'Props'),
+        inputType: select('type', InputTypes, InputTypes.number, 'Props'),
+        label: text('label', 'Base salary', 'Props'),
+        description: text('description', mockText(30), 'Props'),
+        disabled: boolean('disabled', false, 'Props'),
+        required: boolean('required', false, 'Props'),
+        readonly: boolean('readonly', false, 'Props'),
+        hintMessage: text(
+          'hintMessage',
+          'This field should contain something',
+          'Props'
+        ),
+        errorMessage: text('errorMessage', '', 'Props'),
         elementChange: action('Split input single select change'),
-        selectOptions: object('selectOptions', optionsMock),
+        selectOptions: object('selectOptions', optionsMock, 'Options'),
       },
       moduleMetadata: {
         imports: [

--- a/projects/ui-framework/src/lib/form-elements/textarea/textarea.component.html
+++ b/projects/ui-framework/src/lib/form-elements/textarea/textarea.component.html
@@ -13,7 +13,7 @@
             [attr.name]="id"
             [attr.placeholder]="hideLabelOnFocus && label ? (!required ? label : label + '*') : placeholder"
             [value]="value"
-            [disabled]="disabled"
+            [disabled]="disabled || readonly"
             [required]="required"
             [readonly]="readonly"
             [attr.minlength]="minChars || null"

--- a/projects/ui-framework/src/lib/form-elements/textarea/textarea.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/textarea/textarea.stories.ts
@@ -12,6 +12,9 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { StoryBookLayoutModule } from '../../story-book-layout/story-book-layout.module';
 import { mockText } from '../../mock.const';
 
+import formElemsPropsDoc from '../form-elements.properties.md';
+import inputElemsPropsDoc from '../input.properties.md';
+
 const story = storiesOf(ComponentGroupType.FormElements, module).addDecorator(
   withKnobs
 );
@@ -47,27 +50,13 @@ const note = `
   #### Module
   *TextareaModule* or *FormElementsModule*
 
-  #### Properties
-  Name | Type | Description | Default
-  --- | --- | --- | ---
-  [value] | string/number/float | type of input field | &nbsp;
-  [label] | string | label text | &nbsp;
-  [description] | string | description text (above icon) | &nbsp;
-  [placeholder] | string | placeholder text (inside input) | &nbsp;
-  [minChars] | number | minimum length | &nbsp;
-  [maxChars] | number | maximum characters | &nbsp;
-  [showCharCounter] | boolean | set to false to hide character counter | true
-  [readonly] | boolean | disables input | false
-  [disabled] | boolean | is field disabled | false
-  [required] | boolean | is field required | false
-  [hintMessage] | text | hint text | &nbsp;
-  [warnMessage] | string | warning text | &nbsp;
-  [errorMessage] | text | error text | &nbsp;
-  (inputEvents) | EventEmitter<wbr>&lt;InputEvent&gt; | input events emitter | &nbsp;
-
   ~~~
   ${template}
   ~~~
+
+  ${inputElemsPropsDoc}
+
+  ${formElemsPropsDoc}
 `;
 story.add(
   'Textarea',

--- a/projects/ui-framework/src/lib/form-elements/timepicker/timepicker.component.html
+++ b/projects/ui-framework/src/lib/form-elements/timepicker/timepicker.component.html
@@ -5,7 +5,7 @@
 <div class="bfe-wrap has-prefix"
      [ngClass]="{
         focused: hoursFocused || minutesFocused,
-        'has-suffix': !isInputEmpty()
+        'has-suffix': !isInputEmpty() && !readonly
      }"
      (click.outside-zone)="inputHours.focus()">
 
@@ -26,8 +26,9 @@
            maxlength="2"
            placeholder="00"
            [value]="valueHours || null"
-           [disabled]="disabled"
+           [disabled]="disabled || readonly"
            [required]="required"
+           [readonly]="readonly"
            (blur)="onHoursBlur($event)"
            (keydown.outside-zone)="onInputKeydown($event)"
            (input.outside-zone)="onHoursChange($event)"
@@ -43,8 +44,9 @@
            maxlength="2"
            placeholder="00"
            [value]="valueMinutes || null"
-           [disabled]="disabled"
+           [disabled]="disabled || readonly"
            [required]="required"
+           [readonly]="readonly"
            (blur)="onMinutesBlur($event);"
            (keydown.outside-zone)="onInputKeydown($event)"
            (input.outside-zone)="onMinutesChange($event)"
@@ -53,7 +55,7 @@
 
   </span>
 
-  <span [hidden]="isInputEmpty()"
+  <span [hidden]="isInputEmpty() || readonly"
         class="bfe-suffix">
     <b-icon class="clear-input"
             role="button"

--- a/projects/ui-framework/src/lib/form-elements/timepicker/timepicker.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/timepicker/timepicker.stories.ts
@@ -7,6 +7,8 @@ import { ComponentGroupType } from '../../consts';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { StoryBookLayoutModule } from '../../story-book-layout/story-book-layout.module';
 
+import formElemsPropsDoc from '../form-elements.properties.md';
+
 const story = storiesOf(ComponentGroupType.FormElements, module).addDecorator(
   withKnobs
 );
@@ -17,6 +19,7 @@ const template = `
         [label]="label"
         [disabled]="disabled"
         [required]="required"
+        [readonly]="readonly"
         [hintMessage]="hintMessage"
         [warnMessage]="warnMessage"
         [errorMessage]="errorMessage"
@@ -37,21 +40,17 @@ const note = `
   #### Module
   *InputModule* or *FormElementsModule*
 
+  ~~~
+  ${template}
+  ~~~
+
   #### Properties
   Name | Type | Description
   --- | --- | ---
   [value] | string | value of input field ('HH:MM')
-  [label] | string | label text (above input)
-  [disabled] | boolean | is field disabled
-  [required] | boolean | is field required
-  [hintMessage] | string | hint text
-  [warnMessage] | string | warning text
-  [errorMessage] | string | error text
   (changed) | InputEvent | change emitter
 
-  ~~~
-  ${template}
-  ~~~
+  ${formElemsPropsDoc}
 `;
 story.add(
   'Timepicker',
@@ -66,6 +65,7 @@ story.add(
 
         disabled: boolean('disabled', false),
         required: boolean('required', false),
+        readonly: boolean('readonly', false),
 
         hintMessage: text('hintMessage', 'This field should contain something'),
         warnMessage: text('warnMessage', ''),


### PR DESCRIPTION
- better readonly mode for form elements (datepickers in particular)
- form elements stories have been updated to use same .md file for common properties in Notes
- split-input-single-select - removed min-width for select panel