### PR TITLE
fix recursive filter bug

### DIFF
--- a/projects/ui-framework/src/lib/services/utils/functional-utils.ts
+++ b/projects/ui-framework/src/lib/services/utils/functional-utils.ts
@@ -630,7 +630,10 @@ export const recursiveFilter = <T = any>(
   return array.reduce((acc: T[], o) => {
     if (fn(o)) {
       const children = recursiveFilter(o[childrenKey] || [], childrenKey, fn);
-      acc.push(Object.assign({}, o, children.length && { children }));
+      acc.push(Object.assign({}, o, children.length
+        ? { [childrenKey]: children }
+        : { [childrenKey]: [] }
+      ));
     }
     return acc;
   }, []);


### PR DESCRIPTION
the bug was that if all children are archived, they remain from the parent which was not archived, so if the children length is zero, the object needs to assign an empty array