### PR TITLE
Pavel/collapsible css refactor

### DIFF
--- a/projects/ui-framework/bob-rte/src/rte-view/rte-view.component.scss
+++ b/projects/ui-framework/bob-rte/src/rte-view/rte-view.component.scss
@@ -6,16 +6,7 @@
   text-align: left;
 
   a {
-    @include b-link;
-  }
-
-  [mention-employee-id] {
-    color: var(--primary-500);
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
+    @include b-link($color-link-primary);
   }
 
   [data-placeholder-id] {
@@ -106,10 +97,6 @@
       $min-val: $font-size-body,
       $max-val: $font-size-big-body
     );
-  }
-
-  a {
-    color: var(--primary-500);
   }
 }
 

--- a/projects/ui-framework/src/lib/html-css/docs/global-classes.md
+++ b/projects/ui-framework/src/lib/html-css/docs/global-classes.md
@@ -14,7 +14,7 @@
   <tbody>
 
     <tr>
-      <td>mrg-8, mrg-16, mrg-24, mrg-32, mrg-40</td>
+      <td>mrg-0, mrg-8, mrg-16, mrg-24, mrg-32, mrg-40</td>
       <td>Add <u>margin</u> on all sides:<br> 8px, 16px, 24px, 32px, 40px
       </td>
       <td>
@@ -25,9 +25,9 @@
     </tr>
 
     <tr>
-      <td>mrg-l-8, mrg-l-16, mrg-l-24, mrg-l-32, mrg-l-40
+      <td>mrg-l-0, mrg-l-8, mrg-l-16, mrg-l-24, mrg-l-32, mrg-l-40
         <hr>
-        mrg-r-8, mrg-r-16, mrg-r-24, mrg-r-32, mrg-r-40
+        mrg-r-0, mrg-r-8, mrg-r-16, mrg-r-24, mrg-r-32, mrg-r-40
       </td>
       <td>Add <u>margin</u> left or right:<br> 8px, 16px, 24px, 32px, 40px
       </td>
@@ -39,9 +39,9 @@
     </tr>
 
     <tr>
-      <td>mrg-t-8, mrg-t-16, mrg-t-24, mrg-t-32, mrg-t-40
+      <td>mrg-t-0, mrg-t-8, mrg-t-16, mrg-t-24, mrg-t-32, mrg-t-40
         <hr>
-        mrg-b-8, mrg-b-16, mrg-b-24, mrg-b-32, mrg-b-40
+        mrg-b-0, mrg-b-8, mrg-b-16, mrg-b-24, mrg-b-32, mrg-b-40
       </td>
       <td>Add <u>margin</u> top or bottom:<br> 8px, 16px, 24px, 32px, 40px
       </td>
@@ -53,7 +53,7 @@
     </tr>
 
     <tr>
-      <td>pad-8, pad-16, pad-24, pad-32, pad-40</td>
+      <td>pad-0, pad-8, pad-16, pad-24, pad-32, pad-40</td>
       <td>Add <u>padding</u> on all sides:<br> 8px, 16px, 24px, 32px, 40px
       </td>
       <td>
@@ -64,9 +64,9 @@
     </tr>
 
     <tr>
-      <td>pad-l-8, pad-l-16, pad-l-24, pad-l-32, pad-l-40
+      <td>pad-l-0, pad-l-8, pad-l-16, pad-l-24, pad-l-32, pad-l-40
         <hr>
-        pad-r-8, pad-r-16, pad-r-24, pad-r-32, pad-r-40
+        pad-r-0, pad-r-8, pad-r-16, pad-r-24, pad-r-32, pad-r-40
       </td>
       <td>Add <u>padding</u> left or right:<br> 8px, 16px, 24px, 32px, 40px
       </td>
@@ -78,9 +78,9 @@
     </tr>
 
     <tr>
-      <td>pad-t-8, pad-t-16, pad-t-24, pad-t-32, pad-t-40
+      <td>pad-t-0, pad-t-8, pad-t-16, pad-t-24, pad-t-32, pad-t-40
         <hr>
-        pad-b-8, pad-b-16, pad-b-24, pad-b-32, pad-b-40
+        pad-b-0, pad-b-8, pad-b-16, pad-b-24, pad-b-32, pad-b-40
       </td>
       <td>Add <u>padding</u> top or bottom:<br> 8px, 16px, 24px, 32px, 40px
       </td>
@@ -178,6 +178,31 @@
       </td>
       <td>
         <pre><code>&lt;div class="bg-primary-500"&gt;
+  Something
+&lt;/div&gt;</code></pre>
+      </td>
+    </tr>
+
+    <tr>
+      <td>clr-white,
+        clr-grey-100, clr-grey-300, clr-grey-500, clr-grey-600, clr-grey-700
+      </td>
+      <td>Common grey text colors
+      </td>
+      <td>
+        <pre><code>&lt;div class="clr-grey-100"&gt;
+  Something
+&lt;/div&gt;</code></pre>
+      </td>
+    </tr>
+
+    <tr>
+      <td>clr-primary-500, clr-secondary-500, clr-inform-500, clr-negative-500, clr-positive-500
+      </td>
+      <td>Common brand text colors
+      </td>
+      <td>
+        <pre><code>&lt;div class="clr-primary-500"&gt;
   Something
 &lt;/div&gt;</code></pre>
       </td>

--- a/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.html
+++ b/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.html
@@ -1,28 +1,21 @@
-<section class="{{panelID}} bcp-section"
+<section class="bcp-section {{panelID}}"
          [attr.aria-disabled]="disabled || null"
-         [ngClass]="{
-          'bcp-section-collapsible': collapsible,
-          'bcp-section-not-collapsible': !collapsible,
-          'bcp-section-expanded': collapsible && expanded,
-          'bcp-section-collapsed': collapsible && !expanded,
-          'bcp-section-not-divided': !divided,
-          'bcp-disable-animation': options?.disableAnimation || disableAnimation
-         }">
+         [attr.data-collapsible]="!!collapsible"
+         [attr.data-expanded]="!collapsible ? null : !!expanded"
+         [attr.data-divided]="!!divided">
 
   <header *ngIf="title || hasHeaderContent"
-          class="{{panelID}} bcp-header"
+          class="bcp-header {{panelID}}"
           [attr.id]="panelID+'-header'"
+          [attr.data-collapsible]="!!collapsible"
           [attr.aria-controls]="(collapsible && panelID) || null"
-          [attr.aria-expanded]="(collapsible && expanded) || null"
-          [ngClass]="{
-            'b-icon-chevron-right': collapsible && !expanded,
-            'b-icon-chevron-down': collapsible && expanded
-          }"
+          [attr.aria-expanded]="!collapsible ? null : !!expanded"
+          [attr.data-icon-before]="!collapsible ? null : expanded ? 'chevron-down' : 'chevron-right'"
           (click)="togglePanel()">
 
     <div *ngIf="title"
-         class="{{panelID}} bcp-title-wrap"
-         [ngClass]="{'bcp-title-wrap-column': options?.titlesAsColumn}">
+         class="bcp-title-wrap {{panelID}}"
+         [ngClass]="{'flx-col': options?.titlesAsColumn}">
 
       <h4 class="bcp-title"
           [ngClass]="{'b-display-3': !options?.smallTitle, 'b-bold-body': options?.smallTitle}">{{title}}</h4>
@@ -34,30 +27,30 @@
     <div *ngIf="hasHeaderContent"
          #headerContent
          class="bcp-header-content"
-         [ngClass]="{'bcp-header-content-clickable': collapsible && !options.headerTranscludeStopPropagation}"
-         (click.outside-zone)="options.headerTranscludeStopPropagation && $event.stopPropagation()">
+         [attr.data-clickable]="(collapsible && options?.headerTranscludeStopPropagation !== true) || null"
+         (click.outside-zone)="options?.headerTranscludeStopPropagation && $event.stopPropagation()">
       <ng-content select="[header]"></ng-content>
     </div>
 
   </header>
 
-  <div class="{{panelID}} bcp-panel"
+  <div class="bcp-panel {{panelID}}"
        *ngIf="!collapsible || expanded || contentLoaded"
-       [ngClass]="{
-         'bcp-panel-collapsed': collapsible && !expanded,
-         'bcp-panel-expanded': collapsible && expanded,
-         'bcp-panel-starts-expanded': startsExpanded
-       }"
        [attr.id]="panelID"
-       [attr.aria-labelledby]="panelID+'-header'">
-    <div class="{{panelID}} bcp-panel-content-wrap"
+       [attr.aria-labelledby]="panelID+'-header'"
+       [attr.data-collapsible]="!!collapsible"
+       [attr.data-expanded]="!collapsible || startsExpanded ? null : !!expanded">
+
+    <div class="bcp-panel-content-wrap {{panelID}}"
+        [attr.data-collapsible]="!!collapsible"
+        [attr.data-expanded]="!collapsible ? null : !!expanded"
          #panelContent>
       <ng-content></ng-content>
     </div>
 
     <footer *ngIf="hasFooterContent"
             #footerContent
-            class="{{panelID}} bcp-panel-footer">
+            class="bcp-panel-footer {{panelID}}">
       <ng-content select="[footer]"></ng-content>
     </footer>
   </div>

--- a/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.html
+++ b/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.html
@@ -15,10 +15,10 @@
 
     <div *ngIf="title"
          class="bcp-title-wrap {{panelID}}"
-         [ngClass]="{'flx-col': options?.titlesAsColumn}">
+         [ngClass]="{'flx-col': options.titlesAsColumn}">
 
       <h4 class="bcp-title"
-          [ngClass]="{'b-display-3': !options?.smallTitle, 'b-bold-body': options?.smallTitle}">{{title}}</h4>
+          [ngClass]="{'b-display-3': !options.smallTitle, 'b-bold-body': options.smallTitle}">{{title}}</h4>
 
       <p *ngIf="description"
          class="bcp-description">{{description}}</p>
@@ -27,8 +27,8 @@
     <div *ngIf="hasHeaderContent"
          #headerContent
          class="bcp-header-content"
-         [attr.data-clickable]="(collapsible && options?.headerTranscludeStopPropagation !== true) || null"
-         (click.outside-zone)="options?.headerTranscludeStopPropagation && $event.stopPropagation()">
+         [attr.data-clickable]="(collapsible && options.headerTranscludeStopPropagation !== true) || null"
+         (click.outside-zone)="options.headerTranscludeStopPropagation && $event.stopPropagation()">
       <ng-content select="[header]"></ng-content>
     </div>
 
@@ -42,8 +42,8 @@
        [attr.data-expanded]="!collapsible || startsExpanded ? null : !!expanded">
 
     <div class="bcp-panel-content-wrap {{panelID}}"
-        [attr.data-collapsible]="!!collapsible"
-        [attr.data-expanded]="!collapsible ? null : !!expanded"
+         [attr.data-collapsible]="!!collapsible"
+         [attr.data-expanded]="!collapsible ? null : !!expanded"
          #panelContent>
       <ng-content></ng-content>
     </div>

--- a/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.scss
+++ b/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.scss
@@ -4,14 +4,39 @@ $bcp-transition-length: 0.35s;
 $bcp-transition-easing: cubic-bezier(0.645, 0.045, 0.355, 1);
 $bcp-border-color: $border-color-light;
 
+@keyframes bcs-collapse {
+  0% {
+    overflow-y: visible;
+    max-height: none;
+  }
+  1% {
+    overflow-y: hidden;
+    max-height: var(--panel-height, 500px);
+  }
+  100% {
+    overflow: hidden;
+    max-height: 0px;
+  }
+}
+
+@keyframes bcs-expand {
+  0% {
+    overflow-y: hidden;
+    max-height: 0px;
+  }
+  99% {
+    overflow-y: hidden;
+    max-height: var(--panel-height, 500px);
+  }
+  100% {
+    overflow-y: visible;
+    max-height: none;
+  }
+}
+
 :host {
   display: block;
   text-align: left;
-}
-
-h4,
-p {
-  margin: 0;
 }
 
 .bcp-section {
@@ -34,21 +59,13 @@ p {
   }
 }
 
-// footer
-
-.bcp-panel-footer {
-  padding: times8(3) times8(4);
-  border-top: 1px solid $bcp-border-color;
-}
-
 // header
 
 .bcp-header {
   padding: times8(2) times8(4);
 
   @include desktop {
-    border-top-left-radius: $border-radius;
-    border-top-right-radius: $border-radius;
+    border-radius: $border-radius;
   }
 }
 
@@ -67,7 +84,7 @@ p {
   }
 }
 
-.bcp-title-wrap {
+.bcp-title-wrap::ng-deep {
   flex-wrap: wrap;
   user-select: none;
 
@@ -75,10 +92,14 @@ p {
     flex-direction: column;
     align-items: flex-start;
   }
+
+  h4,
+  p {
+    margin: 0;
+  }
 }
 
-.bcp-title-wrap-column {
-  flex-direction: column;
+.flx-col {
   align-items: flex-start;
 }
 
@@ -130,11 +151,22 @@ p {
   color: $grey-600;
 }
 
-.bcp-header-content-clickable {
+[data-clickable='true'] {
   cursor: pointer;
 }
 
+// footer
+
+.bcp-panel-footer {
+  border-top: 1px solid $bcp-border-color;
+  padding: times8(3);
+}
+
 // Panel
+
+.bcp-panel-content-wrap {
+  padding: times8(4);
+}
 
 .bcp-panel {
   border-top: 1px solid $bcp-border-color;
@@ -155,90 +187,90 @@ p {
   }
 }
 
-.bcp-section-not-collapsible {
-  .bcp-panel-content-wrap {
-    padding: times8(4);
-
-    &:empty {
-      padding: 0;
-      margin-top: -1px;
-    }
+.bcp-panel-content-wrap[data-collapsible='false'] {
+  &:empty {
+    margin-top: -1px;
   }
 }
 
-.bcp-section-collapsible {
-  .bcp-header {
-    cursor: pointer;
+// Collapse/expand animation
+
+.bcp-header[data-collapsible='true'] {
+  cursor: pointer;
+  transition-duration: $bcp-transition-length;
+}
+
+.bcp-panel[data-collapsible='true'] {
+  overflow-x: visible;
+  overflow-y: hidden;
+  @include hide-scrollbar;
+
+  will-change: padding, border-width, max-height, min-height;
+  transition-property: padding, border-top-width, max-height, min-height;
+  transition-duration: $bcp-transition-length;
+  transition-timing-function: $bcp-transition-easing;
+  animation-duration: $bcp-transition-length;
+  animation-fill-mode: both;
+
+  max-height: var(--panel-height, none);
+  min-height: 0;
+}
+
+.bcp-panel-content-wrap[data-collapsible='true'] {
+  will-change: opacity;
+  transition-property: opacity;
+  transition-duration: $bcp-transition-length;
+  transition-timing-function: $bcp-transition-easing;
+  opacity: 1;
+
+  &:empty {
+    @include mini-preloader($base-selector: '&');
+    min-height: 100px;
   }
+}
 
-  .bcp-panel {
-    padding: times8(3) times8(4);
-    transition: padding $bcp-transition-length,
-      border-width $bcp-transition-length;
-    will-change: padding, border-width;
-    transition-timing-function: $bcp-transition-easing;
+.bcp-panel[data-expanded='false'] {
+  animation-name: bcs-collapse;
+  padding-top: 0;
+  padding-bottom: 0;
+  border-top-width: 0;
+  border-bottom-width: 0;
+  min-height: 0;
+  max-height: 0;
+}
+
+.bcp-panel-content-wrap[data-expanded='false'] {
+  opacity: 0;
+
+  &:before {
+    display: none;
   }
+}
 
-  .bcp-panel-content-wrap {
-    overflow: hidden;
-    transition: max-height $bcp-transition-length,
-      opacity $bcp-transition-length, min-height $bcp-transition-length;
-    will-change: max-height, opacity, min-height;
-    transition-timing-function: $bcp-transition-easing;
-    opacity: 1;
-    max-height: var(--panel-height, none);
-    min-height: 0;
-    animation-duration: $bcp-transition-length;
-    animation-fill-mode: both;
+.bcp-panel[data-expanded='true'] {
+  animation-name: bcs-expand;
+}
 
-    &:empty {
-      @include mini-preloader($base-selector: '&');
-      min-height: 100px;
-    }
-  }
-
-  .bcp-panel-collapsed {
-    padding-top: 0;
-    padding-bottom: 0;
-    border-top-width: 0;
-
-    .bcp-panel-content-wrap {
-      min-height: 0;
-      max-height: 0;
-      opacity: 0;
-      animation-name: bcs-collapse;
-
-      &:before {
-        display: none;
-      }
-    }
-  }
-
-  .bcp-panel-expanded {
-    .bcp-panel-content-wrap {
-      animation-name: bcs-expand;
-    }
-  }
-
-  .bcp-panel-starts-expanded {
-    .bcp-panel-content-wrap {
-      animation: none;
-      transition: none;
-    }
-  }
+.bcp-header[aria-expanded='false'] {
+  transition-duration: 0s;
+  transition-delay: $bcp-transition-length - 0.05s;
 }
 
 @include desktop {
-  .bcp-section-collapsible {
-    transition: border-color 0.1s, transform 0.1s, box-shadow 0.1s;
+  .bcp-section[data-collapsible='true'] {
+    transition-property: border-color, transform, box-shadow;
+    transition-duration: 0.1s;
     will-change: border-color, transform, box-shadow;
   }
 
-  .bcp-section-collapsed {
-    transition-delay: 0.1s;
+  .bcp-header[data-collapsible='true'] {
+    transition-property: border-radius;
+    will-change: border-radius;
   }
 
-  .bcp-section-collapsed {
+  .bcp-section[data-expanded='false'] {
+    transition-delay: 0.1s;
+
     &:hover {
       box-shadow: 0 3px 7px 0 $boxShadowColor;
       @include desktop {
@@ -249,37 +281,34 @@ p {
   }
 }
 
-.bcp-section-not-collapsible,
-.bcp-section.bcp-section-expanded {
-  .bcp-header {
-    box-shadow: 0 1px 0 0 $bcp-border-color;
-  }
+.bcp-header[data-collapsible='false'],
+.bcp-header[aria-expanded='true'] {
+  box-shadow: 0 1px 0 0 $bcp-border-color;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 // Options
 
-.bcp-section.bcp-section-not-divided {
-  .bcp-header {
+.bcp-section[data-divided='false']::ng-deep {
+  & > .bcp-header {
     box-shadow: none;
   }
-  .bcp-panel {
+
+  & > .bcp-panel {
     border-top: 0;
   }
-  .bcp-footer {
+
+  & > .bcp-panel > .bcp-panel-footer {
     border: 0;
   }
 }
 
-.bcp-disable-animation {
-  .bcp-panel,
-  .bcp-panel-content-wrap,
-  .bcp-section-collapsible,
-  .bcp-section-collapsed {
+:host[data-animation-disabled='true'] {
+  [data-expanded] {
     transition-duration: 0s !important;
     transition-delay: 0s !important;
-  }
-  .bcp-panel-content-wrap {
     animation-duration: 0s !important;
-    animation-duration: 0s !important;
+    animation-delay: 0s !important;
   }
 }

--- a/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.spec.ts
+++ b/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.spec.ts
@@ -91,8 +91,8 @@ describe('CollapsibleSectionComponent', () => {
     });
 
     it('should default to non-collapsible section', () => {
-      expect(collapsibleSection.classList).not.toContain(
-        'bcp-section-collapsible'
+      expect(collapsibleSection.getAttribute('data-collapsible')).toEqual(
+        'false'
       );
       expect(collapsiblePanel).toBeTruthy();
     });
@@ -148,7 +148,9 @@ describe('CollapsibleSectionComponent', () => {
     });
 
     it('should start with panel collapsed', () => {
-      expect(collapsibleSection.classList).toContain('bcp-section-collapsible');
+      expect(collapsibleSection.getAttribute('data-collapsible')).toEqual(
+        'true'
+      );
       expect(collapsibleSection.classList).not.toContain(
         'bcp-section-expanded'
       );
@@ -169,8 +171,8 @@ describe('CollapsibleSectionComponent', () => {
       collapsiblePanel = elementFromFixture(fixture, '.bcp-panel');
 
       expect(collapsiblePanel).toBeTruthy();
-      expect(collapsibleSection.classList).toContain('bcp-section-expanded');
-      expect(collapsiblePanel.classList).toContain('bcp-panel-expanded');
+      expect(collapsibleSection.getAttribute('data-expanded')).toEqual('true');
+      expect(collapsiblePanel.getAttribute('data-expanded')).toEqual('true');
       expect(collapsibleComponent.opened.emit).toHaveBeenCalled();
     });
 
@@ -181,8 +183,8 @@ describe('CollapsibleSectionComponent', () => {
       collapsiblePanel = elementFromFixture(fixture, '.bcp-panel');
 
       expect(collapsiblePanel).toBeTruthy();
-      expect(collapsibleSection.classList).toContain('bcp-section-expanded');
-      expect(collapsiblePanel.classList).toContain('bcp-panel-expanded');
+      expect(collapsibleSection.getAttribute('data-expanded')).toEqual('true');
+      expect(collapsiblePanel.getAttribute('data-expanded')).toEqual('true');
       expect(collapsibleComponent.opened.emit).toHaveBeenCalled();
 
       flush();
@@ -192,26 +194,22 @@ describe('CollapsibleSectionComponent', () => {
       emitNativeEvent(collapsibleHeader, 'click');
       fixture.detectChanges();
 
-      expect(collapsibleSection.classList).toContain('bcp-section-expanded');
+      expect(collapsibleSection.getAttribute('data-expanded')).toEqual('true');
 
       emitNativeEvent(collapsibleHeader, 'click');
       fixture.detectChanges();
 
-      expect(collapsibleSection.classList).not.toContain(
-        'bcp-section-expanded'
-      );
+      expect(collapsibleSection.getAttribute('data-expanded')).toEqual('false');
       expect(collapsibleHeader.classList).not.toContain('no-shadow');
       expect(collapsiblePanel.classList).not.toContain('no-top-border');
       expect(collapsibleComponent.closed.emit).toHaveBeenCalled();
     });
 
     it('should not show divider when divided = false', () => {
-      expect(collapsibleSection.classList).not.toContain(
-        'bcp-section-not-divided'
-      );
+      expect(collapsibleSection.getAttribute('data-divided')).toEqual('true');
       collapsibleComponent.divided = false;
       fixture.detectChanges();
-      expect(collapsibleSection.classList).toContain('bcp-section-not-divided');
+      expect(collapsibleSection.getAttribute('data-divided')).toEqual('false');
     });
 
     it('should put CSS variable with content height on component host element', () => {
@@ -219,7 +217,7 @@ describe('CollapsibleSectionComponent', () => {
       fixture.detectChanges();
 
       expect(collapsibleHost.getAttribute('style')).toContain(
-        '--panel-height:300px;'
+        '--panel-height:3'
       );
     });
 

--- a/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.ts
+++ b/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.ts
@@ -84,11 +84,13 @@ export class CollapsibleSectionComponent
   @ViewChild('footerContent') footerContent: ElementRef;
 
   @HostBinding('attr.data-animation-disabled') get animationDisabled() {
-    return this.options?.disableAnimation || this.disableAnimation || null;
+    return this.options.disableAnimation || this.disableAnimation || null;
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    applyChanges(this, changes);
+    applyChanges(this, changes, {
+      options: cloneObject(COLLAPSIBLE_OPTIONS_DEF),
+    });
 
     if (hasChanges(changes, ['options'])) {
       this.options = {

--- a/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.ts
+++ b/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.ts
@@ -13,12 +13,15 @@ import {
   OnChanges,
   OnInit,
   OnDestroy,
+  HostBinding,
 } from '@angular/core';
 import { DOMhelpers } from '../../services/html/dom-helpers.service';
 import {
   simpleUID,
   notFirstChanges,
   cloneObject,
+  applyChanges,
+  hasChanges,
 } from '../../services/utils/functional-utils';
 import { UtilsService } from '../../services/utils/utils.service';
 import { Subscription } from 'rxjs';
@@ -26,7 +29,7 @@ import { outsideZone } from '../../services/utils/rxjs.operators';
 import { CollapsibleOptions } from './collapsible-section.interface';
 import { ColorService } from '../../services/color-service/color.service';
 
-const collapsibleOptionsDef: CollapsibleOptions = {
+export const COLLAPSIBLE_OPTIONS_DEF: CollapsibleOptions = {
   smallTitle: false,
   titlesAsColumn: true,
   headerTranscludeStopPropagation: false,
@@ -47,15 +50,14 @@ export class CollapsibleSectionComponent
     private zone: NgZone,
     private cd: ChangeDetectorRef,
     private colorService: ColorService
-  ) {
-  }
+  ) {}
 
   public hasHeaderContent = true;
   public hasPanelContent = true;
   public hasFooterContent = true;
   public contentLoaded = false;
   public startsExpanded = false;
-  public disableAnimation = false;
+
   private contentHeight = 0;
   private resizeSubscription: Subscription;
   private firstExpand = false;
@@ -70,7 +72,8 @@ export class CollapsibleSectionComponent
   @Input() title: string;
   @Input() description?: string;
 
-  @Input() options: CollapsibleOptions = cloneObject(collapsibleOptionsDef);
+  @Input() options: CollapsibleOptions = cloneObject(COLLAPSIBLE_OPTIONS_DEF);
+  @Input() disableAnimation = false;
 
   @Output() opened: EventEmitter<void> = new EventEmitter<void>();
   @Output() openedFirst: EventEmitter<void> = new EventEmitter<void>();
@@ -80,11 +83,17 @@ export class CollapsibleSectionComponent
   @ViewChild('panelContent') panelContent: ElementRef;
   @ViewChild('footerContent') footerContent: ElementRef;
 
+  @HostBinding('attr.data-animation-disabled') get animationDisabled() {
+    return this.options?.disableAnimation || this.disableAnimation || null;
+  }
+
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.options) {
+    applyChanges(this, changes);
+
+    if (hasChanges(changes, ['options'])) {
       this.options = {
-        ...collapsibleOptionsDef,
-        ...changes.options.currentValue,
+        ...COLLAPSIBLE_OPTIONS_DEF,
+        ...this.options,
       };
 
       if (this.options.indicatorColor) {
@@ -103,19 +112,25 @@ export class CollapsibleSectionComponent
       }
     }
 
-    if (changes.expanded) {
+    if (hasChanges(changes, ['expanded'])) {
       if (!changes.expanded.firstChange) {
-        this.togglePanel(changes.expanded.currentValue);
+        this.togglePanel(this.expanded);
       } else {
-        this.startsExpanded = changes.expanded.currentValue;
+        this.startsExpanded = this.expanded;
       }
     }
 
-    if (changes.panelID && !changes.panelID.firstChange) {
+    if (notFirstChanges(changes, ['panelID'])) {
       this.disableAnimation = true;
       this.cd.detectChanges();
-      setTimeout(() => {
-        this.disableAnimation = false;
+
+      this.zone.runOutsideAngular(() => {
+        setTimeout(() => {
+          this.disableAnimation = false;
+          if (!this.cd['destroyed']) {
+            this.cd.detectChanges();
+          }
+        }, 0);
       });
     }
 
@@ -199,9 +214,10 @@ export class CollapsibleSectionComponent
   private setCssVars(repeat = false): void {
     if (this.panelContent) {
       this.contentHeight =
-        this.panelContent.nativeElement.scrollHeight > 100
-          ? this.panelContent.nativeElement.scrollHeight
-          : 500;
+        this.panelContent.nativeElement.scrollHeight +
+        (this.footerContent?.nativeElement.scrollHeight || 0);
+
+      this.contentHeight = this.contentHeight > 100 ? this.contentHeight : 500;
 
       this.DOM.setCssProps(this.host.nativeElement, {
         '--panel-height': this.contentHeight + 'px',

--- a/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.stories.ts
+++ b/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.stories.ts
@@ -99,7 +99,7 @@ const note = `
      variables, that you can use for custom color mods in your feature css, \
      for example: \`color: var(--bcp-color)\`, or for rgba color with opacity \
      - \`color: rgba(var(--bcp-color-rgb), 0.2)\` \
-     | collapsibleOptionsDef
+     | COLLAPSIBLE<sub>-</sub>OPTIONS<sub>-</sub>DEF
   **(openedFirst)** |  EventEmitter<wbr>&lt;void&gt; | emits when collapsible panel is *opened first time*. <br> Bind to this to fetch or init data. | &nbsp;
   (opened) |  EventEmitter<wbr>&lt;void&gt; | emits when collapsible panel is opened | &nbsp;
   (closed) |  EventEmitter<wbr>&lt;void&gt; | emits when collapsible panel is closed | &nbsp;

--- a/projects/ui-framework/src/lib/layout/sortable-collapsible-sections/sortable-collapsible-sections.component.scss
+++ b/projects/ui-framework/src/lib/layout/sortable-collapsible-sections/sortable-collapsible-sections.component.scss
@@ -70,7 +70,7 @@
 }
 
 .sections.dragging ::ng-deep {
-  .bcp-panel, .bcp-panel-content-wrap, .bcp-section-collapsible, .bcp-section-collapsed {
+  [data-expanded] {
     transition-duration: 0s !important;
     transition-delay: 0s !important;
     animation-duration: 0s !important;

--- a/projects/ui-framework/src/lib/style/atomic.scss
+++ b/projects/ui-framework/src/lib/style/atomic.scss
@@ -161,6 +161,17 @@ $acss-dirs: top right bottom left;
   }
 }
 
+// Layout
+
+.flx {
+  display: flex;
+}
+
+.flx-col {
+  display: flex;
+  flex-direction: column;
+}
+
 // Misc
 
 .rounded {

--- a/projects/ui-framework/src/lib/style/atomic.scss
+++ b/projects/ui-framework/src/lib/style/atomic.scss
@@ -1,4 +1,4 @@
-$acss-sizes: 8 16 24 32 40;
+$acss-sizes: 0 8 16 24 32 40;
 $acss-dirs: top right bottom left;
 
 // Typography
@@ -90,6 +90,10 @@ $acss-dirs: top right bottom left;
   }
 }
 
+.uppercase {
+  text-transform: uppercase;
+}
+
 // Border
 
 .brd {
@@ -147,6 +151,42 @@ $acss-dirs: top right bottom left;
   background-color: var(--positive-500);
 }
 
+.clr-white {
+  color: white;
+}
+
+.clr-grey-100 {
+  color: $grey-100;
+}
+.clr-grey-300 {
+  color: $grey-300;
+}
+.clr-grey-500 {
+  color: $grey-500;
+}
+.clr-grey-600 {
+  color: $grey-600;
+}
+.clr-grey-700 {
+  color: $grey-700;
+}
+
+.clr-primary-500 {
+  color: var(--primary-500);
+}
+.clr-secondary-500 {
+  color: var(--secondary-500);
+}
+.clr-inform-500 {
+  color: var(--inform-500);
+}
+.clr-negative-500 {
+  color: var(--negative-500);
+}
+.clr-positive-500 {
+  color: var(--positive-500);
+}
+
 // Responsive
 
 .b-mobile {
@@ -167,9 +207,19 @@ $acss-dirs: top right bottom left;
   display: flex;
 }
 
+.flx-row {
+  display: flex;
+  flex-direction: row;
+}
+
 .flx-col {
   display: flex;
   flex-direction: column;
+}
+
+.flx-center {
+  align-items: center;
+  justify-content: center;
 }
 
 // Misc

--- a/projects/ui-framework/src/lib/style/colors.scss
+++ b/projects/ui-framework/src/lib/style/colors.scss
@@ -43,6 +43,8 @@ $color-option-selected: $grey-300;
 $color-select-yellow: #fdf4d2; // rgb(253, 244, 210)
 $color-select-red: var(--negative-600);
 
+$color-link-primary: var(--primary-700);
+
 @function black($opacity) {
   @return rgba(0, 0, 0, $opacity);
 }

--- a/projects/ui-framework/src/lib/style/component-mixins/link.mixin.scss
+++ b/projects/ui-framework/src/lib/style/component-mixins/link.mixin.scss
@@ -1,10 +1,12 @@
-@mixin b-link {
-  text-decoration: none;
-  color: inherit;
+@mixin b-link($color: inherit) {
   font-weight: 600;
+  color: $color;
+  text-decoration: none;
 
-  &.primary {
-    color: var(--primary-700);
+  @if $color == inherit {
+    &.primary {
+      color: var(--primary-700);
+    }
   }
 
   &:hover {

--- a/projects/ui-framework/src/lib/style/keyframes.global.scss
+++ b/projects/ui-framework/src/lib/style/keyframes.global.scss
@@ -7,36 +7,6 @@
   }
 }
 
-@keyframes bcs-collapse {
-  0% {
-    overflow: visible;
-    max-height: none;
-  }
-  1% {
-    overflow: hidden;
-    max-height: var(--panel-height, 500px);
-  }
-  100% {
-    overflow: hidden;
-    max-height: 0px;
-  }
-}
-
-@keyframes bcs-expand {
-  0% {
-    overflow: hidden;
-    max-height: 0px;
-  }
-  99% {
-    overflow: hidden;
-    max-height: var(--panel-height, 500px);
-  }
-  100% {
-    overflow: visible;
-    max-height: none;
-  }
-}
-
 @keyframes b-hide {
   0% {
     overflow: hidden;

--- a/projects/ui-framework/src/lib/style/rte/rte.scss
+++ b/projects/ui-framework/src/lib/style/rte/rte.scss
@@ -11,8 +11,6 @@ $rte-placeholder-color: $rte-icon-color;
 $rte-label-to-placeholder: false;
 $rte-hide-label: true;
 
-$rte-link-color: var(--primary-700);
-
 // font-sizes
 
 .fr-element,
@@ -80,15 +78,10 @@ $rte-link-color: var(--primary-700);
   }
 }
 
-.fr-box[class] {
+.fr-element,
+.fr-view {
   a {
-    color: $rte-link-color;
-    text-decoration: underline;
-
-    &:focus {
-      outline: 0;
-      filter: brightness(0.8);
-    }
+    @include b-link($color-link-primary);
   }
 }
 

--- a/projects/ui-framework/src/lib/style/style.scss
+++ b/projects/ui-framework/src/lib/style/style.scss
@@ -50,6 +50,14 @@ body {
   @include b-body($color: $body-text-color, $addCssVars: true);
 }
 
+a {
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 .preloading,
 .preloading-collapsed {
   @include mini-preloader(

--- a/projects/ui-framework/src/public_api.ts
+++ b/projects/ui-framework/src/public_api.ts
@@ -487,7 +487,7 @@ export { DividerModule } from './lib/layout/divider/divider.module';
 export { DividerComponent } from './lib/layout/divider/divider.component';
 // Collapsible Section
 export { CollapsibleSectionModule } from './lib/layout/collapsible-section/collapsible-section.module';
-export { CollapsibleSectionComponent } from './lib/layout/collapsible-section/collapsible-section.component';
+export { CollapsibleSectionComponent, COLLAPSIBLE_OPTIONS_DEF } from './lib/layout/collapsible-section/collapsible-section.component';
 export { CollapsibleOptions } from './lib/layout/collapsible-section/collapsible-section.interface';
 // Draggable Collapsible Sections
 export { SortableCollapsibleSectionsModule } from './lib/layout/sortable-collapsible-sections/sortable-collapsible-sections.module';


### PR DESCRIPTION
collapsibleSection CSS refactor related to collapsibleSections within collapsibleSections style inheritance clashes:
various elements now have their own state attributes, so instead of (for example) `.panel-collapsed .panel-header` we have `.header[collapsed="true"]`. this way style will not apply to other `.panel-header`'s that might be inside

Also:
- collapsibleSection footer was not collapsing - fixed
- RTE + global default link style adjust
- some more global classes