### PR TITLE
Some changes in `columnsChanged` and `columnsOrderChanged` events

### DIFF
--- a/projects/ui-framework/bob-table/src/table/table.stories.ts
+++ b/projects/ui-framework/bob-table/src/table/table.stories.ts
@@ -151,7 +151,7 @@ const note = `
   (gridInit) | EventEmitter<wbr>&lt;void&gt;  | Grid init event | &nbsp;
   (selectionChanged) | EventEmitter<wbr>&lt;any[]&gt; | All selected rows | &nbsp;
   (sortChanged) | EventEmitter<wbr>&lt;SortChangedEvent&gt; | Sort changed event | &nbsp;
-  (columnsChanged) | EventEmitter<wbr>&lt;void&gt; | emits when columns change | &nbsp;
+  (columnsChanged) | EventEmitter<wbr>&lt;ColumnsChangedEvent&gt; | emits when columns change | &nbsp;
   (columnsOrderChanged) | EventEmitter<wbr>&lt;ColumnsOrderChangedEvent&gt; | emits when column order changes | &nbsp;
   (cellClicked) | EventEmitter<wbr>&lt;CellClickedEvent&gt; | emits on cell click | &nbsp;
   (columnRemoved) | EventEmitter<wbr>&lt;string&gt; | Emits Cell ID,\

--- a/projects/ui-framework/bob-table/src/table/table/table.component.ts
+++ b/projects/ui-framework/bob-table/src/table/table/table.component.ts
@@ -24,7 +24,7 @@ import {
 import { cloneDeep, get, has, map } from 'lodash';
 import { TableUtilsService } from '../table-utils-service/table-utils.service';
 import { AgGridWrapper } from './ag-grid-wrapper';
-import { ColumnOrderStrategy, ColumnsOrderChangedEventName, RowSelection, TableType } from './table.enum';
+import { ColumnOrderStrategy, TableEventName, RowSelection, TableType } from './table.enum';
 import {
   ColumnDef,
   ColumnDefConfig, ColumnsChangedEvent,
@@ -210,14 +210,14 @@ export class TableComponent extends AgGridWrapper implements OnInit, OnChanges {
     });
   }
 
-  private setOrderedColumns(columns: Column[], eventName: ColumnsOrderChangedEventName): void {
+  private setOrderedColumns(columns: Column[], eventName: TableEventName): void {
     this.columns = map(columns, (col) => col.colDef.field);
-    this.columnsOrderChanged.emit({ columns: cloneDeep(this.columns), eventName });
+    this.columnsOrderChanged.emit({ columns: this.columns.slice(), eventName });
   }
 
   private emitColumnsChangedEvent(columns: Column[]): void {
     this.columns = map(columns, (col) => col.colDef.field);
-    this.columnsChanged.emit({ columns: cloneDeep(this.columns) });
+    this.columnsChanged.emit({ columns: this.columns.slice() });
   }
 
   private setGridHeight(height: number): void {
@@ -259,7 +259,7 @@ export class TableComponent extends AgGridWrapper implements OnInit, OnChanges {
         if (this.shouldAutoSizeColumns) {
           event.columnApi.autoSizeAllColumns();
         }
-        this.setOrderedColumns(event.columnApi.getAllGridColumns(), ColumnsOrderChangedEventName.onGridReady);
+        this.setOrderedColumns(event.columnApi.getAllGridColumns(), TableEventName.onGridReady);
         this.cdr.markForCheck();
         this.gridInit.emit();
       },
@@ -267,12 +267,12 @@ export class TableComponent extends AgGridWrapper implements OnInit, OnChanges {
         if (this.shouldAutoSizeColumns) {
           event.columnApi.autoSizeAllColumns();
         }
-        this.setOrderedColumns(event.columnApi.getAllGridColumns(), ColumnsOrderChangedEventName.onGridColumnsChanged);
+        this.setOrderedColumns(event.columnApi.getAllGridColumns(), TableEventName.onGridColumnsChanged);
         this.cdr.markForCheck();
         this.emitColumnsChangedEvent(event.columnApi.getAllGridColumns());
       },
       onDragStopped(event: DragStoppedEvent): void {
-        that.setOrderedColumns(event.columnApi.getAllGridColumns(), ColumnsOrderChangedEventName.onDragStopped);
+        that.setOrderedColumns(event.columnApi.getAllGridColumns(), TableEventName.onDragStopped);
       },
       onCellClicked(event: CellClickedEvent): void {
         that.cellClicked.emit(event);

--- a/projects/ui-framework/bob-table/src/table/table/table.component.ts
+++ b/projects/ui-framework/bob-table/src/table/table/table.component.ts
@@ -24,10 +24,10 @@ import {
 import { cloneDeep, get, has, map } from 'lodash';
 import { TableUtilsService } from '../table-utils-service/table-utils.service';
 import { AgGridWrapper } from './ag-grid-wrapper';
-import { ColumnOrderStrategy, RowSelection, TableType } from './table.enum';
+import { ColumnOrderStrategy, ColumnsOrderChangedEventName, RowSelection, TableType } from './table.enum';
 import {
   ColumnDef,
-  ColumnDefConfig,
+  ColumnDefConfig, ColumnsChangedEvent,
   ColumnsOrderChangedEvent,
   RowClickedEvent,
   SortChangedEvent,
@@ -92,7 +92,7 @@ export class TableComponent extends AgGridWrapper implements OnInit, OnChanges {
   >();
   @Output() selectionChanged: EventEmitter<any[]> = new EventEmitter<any[]>();
   @Output() gridInit: EventEmitter<void> = new EventEmitter<void>();
-  @Output() columnsChanged: EventEmitter<void> = new EventEmitter<void>();
+  @Output() columnsChanged: EventEmitter<ColumnsChangedEvent> = new EventEmitter<ColumnsChangedEvent>();
   @Output() columnsOrderChanged: EventEmitter<
     ColumnsOrderChangedEvent
   > = new EventEmitter<ColumnsOrderChangedEvent>();
@@ -210,9 +210,14 @@ export class TableComponent extends AgGridWrapper implements OnInit, OnChanges {
     });
   }
 
-  private setOrderedColumns(columns: Column[]): void {
+  private setOrderedColumns(columns: Column[], eventName: ColumnsOrderChangedEventName): void {
     this.columns = map(columns, (col) => col.colDef.field);
-    this.columnsOrderChanged.emit({ columns: cloneDeep(this.columns) });
+    this.columnsOrderChanged.emit({ columns: cloneDeep(this.columns), eventName });
+  }
+
+  private emitColumnsChangedEvent(columns: Column[]): void {
+    this.columns = map(columns, (col) => col.colDef.field);
+    this.columnsChanged.emit({ columns: cloneDeep(this.columns) });
   }
 
   private setGridHeight(height: number): void {
@@ -254,7 +259,7 @@ export class TableComponent extends AgGridWrapper implements OnInit, OnChanges {
         if (this.shouldAutoSizeColumns) {
           event.columnApi.autoSizeAllColumns();
         }
-        this.setOrderedColumns(event.columnApi.getAllGridColumns());
+        this.setOrderedColumns(event.columnApi.getAllGridColumns(), ColumnsOrderChangedEventName.onGridReady);
         this.cdr.markForCheck();
         this.gridInit.emit();
       },
@@ -262,12 +267,12 @@ export class TableComponent extends AgGridWrapper implements OnInit, OnChanges {
         if (this.shouldAutoSizeColumns) {
           event.columnApi.autoSizeAllColumns();
         }
-        this.setOrderedColumns(event.columnApi.getAllGridColumns());
+        this.setOrderedColumns(event.columnApi.getAllGridColumns(), ColumnsOrderChangedEventName.onGridColumnsChanged);
         this.cdr.markForCheck();
-        this.columnsChanged.emit();
+        this.emitColumnsChangedEvent(event.columnApi.getAllGridColumns());
       },
       onDragStopped(event: DragStoppedEvent): void {
-        that.setOrderedColumns(event.columnApi.getAllGridColumns());
+        that.setOrderedColumns(event.columnApi.getAllGridColumns(), ColumnsOrderChangedEventName.onDragStopped);
       },
       onCellClicked(event: CellClickedEvent): void {
         that.cellClicked.emit(event);

--- a/projects/ui-framework/bob-table/src/table/table/table.enum.ts
+++ b/projects/ui-framework/bob-table/src/table/table/table.enum.ts
@@ -23,3 +23,9 @@ export enum ColumnOrderStrategy {
   AppendNew = 'appendNew',
   Reorder = 'reorder',
 }
+
+export enum ColumnsOrderChangedEventName {
+  onGridReady = 'onGridReady',
+  onGridColumnsChanged = 'onGridColumnsChanged',
+  onDragStopped = 'onDragStopped',
+}

--- a/projects/ui-framework/bob-table/src/table/table/table.enum.ts
+++ b/projects/ui-framework/bob-table/src/table/table/table.enum.ts
@@ -24,7 +24,7 @@ export enum ColumnOrderStrategy {
   Reorder = 'reorder',
 }
 
-export enum ColumnsOrderChangedEventName {
+export enum TableEventName {
   onGridReady = 'onGridReady',
   onGridColumnsChanged = 'onGridColumnsChanged',
   onDragStopped = 'onDragStopped',

--- a/projects/ui-framework/bob-table/src/table/table/table.interface.ts
+++ b/projects/ui-framework/bob-table/src/table/table/table.interface.ts
@@ -1,5 +1,5 @@
 import {
-  ColumnOrderStrategy, ColumnsOrderChangedEventName,
+  ColumnOrderStrategy, TableEventName,
   PinDirection,
   SortDirections,
 } from './table.enum';
@@ -48,13 +48,12 @@ export interface RowNodeDef {
   data: any;
 }
 
-export interface ColumnsOrderChangedEvent {
-  columns: string[];
-  eventName: ColumnsOrderChangedEventName;
-}
-
 export interface ColumnsChangedEvent {
   columns: string[];
+}
+
+export interface ColumnsOrderChangedEvent extends ColumnsChangedEvent {
+  eventName?: TableEventName;
 }
 
 export interface TableStyleConfig {

--- a/projects/ui-framework/bob-table/src/table/table/table.interface.ts
+++ b/projects/ui-framework/bob-table/src/table/table/table.interface.ts
@@ -1,5 +1,5 @@
 import {
-  ColumnOrderStrategy,
+  ColumnOrderStrategy, ColumnsOrderChangedEventName,
   PinDirection,
   SortDirections,
 } from './table.enum';
@@ -49,6 +49,11 @@ export interface RowNodeDef {
 }
 
 export interface ColumnsOrderChangedEvent {
+  columns: string[];
+  eventName: ColumnsOrderChangedEventName;
+}
+
+export interface ColumnsChangedEvent {
   columns: string[];
 }
 


### PR DESCRIPTION
## b-table component
`columnsOrderChanged` event changes: added *eventName* property to the event
`columnsChanged` event changes: now event emits list of columns. Also event changes the internal property *columns* (to be consistent with the event name).