### PR TITLE
- add tooltipTemplate input for donut-chart-text component

### DIFF
--- a/projects/ui-framework/bob-charts/src/charts/donut-chart-text/donut-chart-text.component.html
+++ b/projects/ui-framework/bob-charts/src/charts/donut-chart-text/donut-chart-text.component.html
@@ -10,6 +10,7 @@
 [legendPosition]="legendPosition"
 [extraOptions]="extraOptions"
 [preTooltipValue]="preTooltipValue"
+[tooltipTemplate]="tooltipTemplate"
 [postTooltipValue]="postTooltipValue"
 [tooltipValueFormatter]="tooltipValueFormatter"
 (legendChanged)="updatePosition()"

--- a/projects/ui-framework/bob-charts/src/charts/donut-chart-text/donut-chart-text.component.ts
+++ b/projects/ui-framework/bob-charts/src/charts/donut-chart-text/donut-chart-text.component.ts
@@ -1,6 +1,7 @@
 import {ChangeDetectorRef, Component, ElementRef, Input, ViewChild} from '@angular/core';
 import {Options, SeriesPieDataOptions} from 'highcharts';
-import {ChartLegendPositionEnum} from '../chart/chart.interface';
+import { ChartFormatterThis, ChartLegendPositionEnum } from '../chart/chart.interface';
+import { ChartCore } from '../chart/chart-core';
 
 export const ANIMATION_DURATION = 400;
 
@@ -51,6 +52,16 @@ export class DonutChartTextComponent {
   @ViewChild('chart', { read: ElementRef }) chartComponent: ElementRef;
   @ViewChild('text', { read: ElementRef }) textContainer: ElementRef;
   @Input() tooltipValueFormatter: Function = (val) => val;
+  @Input() tooltipTemplate = <ChartTooltipTemplateFormatter>(
+    component: ChartCore,
+    chartPoint: ChartFormatterThis
+  ) => `<div class="chart-tooltip">
+          <div class="value" style="color:${chartPoint.color};">
+            ${component.formatValue(chartPoint.y)}
+          </div>
+          <div class="key">${chartPoint.key}</div>
+        </div>`;
+
   constructor(
     private cdr: ChangeDetectorRef
   ) {}


### PR DESCRIPTION
Add `tooltipTemplate` input with default value in order to be passed to inner `<b-pie-chart>` component.
This one is especially needed for current task that consists in adding tooltip for pie charts on KPIs.

task link: https://app.asana.com/0/0/1190750135254441/f