### PR TITLE
Always show "card-top" reserved space along with 3 dots on b-card

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.2.184",
+  "version": "4.2.185",
   "peerDependencies": {
     "@angular/animations": "^10.0.2",
     "@angular/cdk": "^10.0.1",

--- a/projects/ui-framework/src/lib/cards/card/card.component.html
+++ b/projects/ui-framework/src/lib/cards/card/card.component.html
@@ -18,8 +18,7 @@
                  (clicked)="card.actionConfig.action($event)">
 </b-square-button>
 
-<div *ngIf="hasTop || card.imageUrl"
-     class="card-top"
+<div class="card-top"
      #cardTop
      [ngStyle]="{ 'background-image': card.imageUrl && 'url(' + card.imageUrl + ')' }"
      [ngClass]="{

--- a/projects/ui-framework/src/lib/cards/card/card.component.ts
+++ b/projects/ui-framework/src/lib/cards/card/card.component.ts
@@ -36,7 +36,6 @@ export class CardComponent extends BaseCardElement implements AfterViewInit {
   readonly iconColor = IconColor;
   readonly linkColor = LinkColor;
   public hasContent = true;
-  public hasTop = true;
   public cardTopTextOnly = false;
 
   public titleMaxLines = 2;
@@ -49,7 +48,6 @@ export class CardComponent extends BaseCardElement implements AfterViewInit {
     this.zone.runOutsideAngular(() => {
       setTimeout(() => {
         this.hasContent = !this.DOM.isEmpty(this.cardContent.nativeElement);
-        this.hasTop = !this.DOM.isEmpty(this.cardTop.nativeElement);
 
         this.cardTopTextOnly =
           this.cardTop.nativeElement.children.length === 1 &&
@@ -65,6 +63,6 @@ export class CardComponent extends BaseCardElement implements AfterViewInit {
   }
 
   private getTitleMaxLines() {
-    return this.hasContent ? 2 : this.card.imageUrl ? 3 : this.hasTop ? 4 : 6;
+    return this.hasContent ? 2 : this.card.imageUrl ? 3 : 4;
   }
 }


### PR DESCRIPTION
Description:

Remove `hasTop` variable in order to hide or show `card-top` block on b-cards. That block will always be displayed.

reference : https://app.asana.com/0/1159939249943132/1184700384671121/f