### PR TITLE
add description tooltips of headers for lists

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.2.194",
+  "version": "4.2.195",
   "peerDependencies": {
     "@angular/animations": "^10.0.2",
     "@angular/cdk": "^10.0.1",

--- a/projects/ui-framework/src/lib/lists/list.interface.ts
+++ b/projects/ui-framework/src/lib/lists/list.interface.ts
@@ -34,6 +34,7 @@ export interface SelectGroupOption {
   groupIndex?: number;
   key?: string | number;
   options: SelectOption[];
+  description?: string;
   selected?: boolean;
   hidden?: boolean;
   groupSelectedIDs?: (number | string)[];

--- a/projects/ui-framework/src/lib/lists/list.scss
+++ b/projects/ui-framework/src/lib/lists/list.scss
@@ -54,7 +54,7 @@
       cursor: pointer;
     }
 
-    &.has-hover,
+    &.has-distinct-hover,
     &.clickable {
       &:hover,
       &.focus {

--- a/projects/ui-framework/src/lib/lists/multi-list/multi-list.component.html
+++ b/projects/ui-framework/src/lib/lists/multi-list/multi-list.component.html
@@ -31,7 +31,7 @@
             'selected': header.selected,
             'indeterminate': header.indeterminate
           }"
-           class="option-select header has-hover">
+           class="option-select header has-distinct-hover">
         <span (click)="headerClick(header)"
               class="header-collapse-trigger">
         </span>
@@ -56,6 +56,17 @@
             ({{header.selectedCount}})
           </span>
         </div>
+
+        <span *ngIf="header.description"
+              class="comp-suffix has-hover"
+              [attr.data-icon-before]="infoIcon"
+              [attr.data-icon-before-color]="iconColor.normal"
+              [attr.data-icon-before-size]="iconSize.small"
+              [matTooltip]="header.description"
+              [matTooltipClass]="tooltipClass"
+              [matTooltipShowDelay]="tooltipDelay"
+              [matTooltipPosition]="tooltipPosition">
+        </span>
       </div>
       <div [ngStyle]="{height: header.isCollapsed ? 0 : header.placeHolderSize + 'px'}"
            class="placeholder"></div>

--- a/projects/ui-framework/src/lib/lists/multi-list/multi-list.component.spec.ts
+++ b/projects/ui-framework/src/lib/lists/multi-list/multi-list.component.spec.ts
@@ -824,4 +824,21 @@ describe('MultiListComponent', () => {
       expect(resetButton.parentElement.getAttributeNames()).toContain('hidden');
     });
   });
+
+  describe('Headers tooltip with description', () => {
+    it('Should have description tooltip', () => {
+      optionsMock[1].description = 'Lorem ipsum';
+      console.log('optionsMock: ', optionsMock);
+      component.ngOnChanges(
+        simpleChange({
+          options: optionsMock,
+          startWithGroupsCollapsed: false,
+        })
+      );
+      fixture.detectChanges();
+      const headerGroups = fixture.debugElement.queryAll(By.css('.headers-group'));
+      const tooltipIcon = headerGroups[1].nativeElement.querySelector('.comp-suffix.has-hover');
+      expect(tooltipIcon).toBeTruthy();
+    });
+  });
 });

--- a/projects/ui-framework/src/lib/lists/multi-list/multi-list.stories.ts
+++ b/projects/ui-framework/src/lib/lists/multi-list/multi-list.stories.ts
@@ -86,6 +86,10 @@ const note = `
 const options = cloneDeep(optionsMock);
 const optionsDef = cloneDeep(optionsMockDef);
 
+options[2].description = 'Lorem ipsum dolor';
+options[4].description = 'Sit amet en ipsum';
+options[6].description = 'Lorem Dolor sit amet en psium';
+
 story.add(
   'Multi list',
   () => ({

--- a/projects/ui-framework/src/lib/lists/single-list/single-list.component.html
+++ b/projects/ui-framework/src/lib/lists/single-list/single-list.component.html
@@ -46,6 +46,17 @@
               class="header-selected-count">
           ({{header.selectedCount}})
         </span>
+
+        <span *ngIf="header.description"
+              class="comp-suffix has-hover"
+              [attr.data-icon-before]="infoIcon"
+              [attr.data-icon-before-color]="iconColor.normal"
+              [attr.data-icon-before-size]="iconSize.small"
+              [matTooltip]="header.description"
+              [matTooltipClass]="tooltipClass"
+              [matTooltipShowDelay]="tooltipDelay"
+              [matTooltipPosition]="tooltipPosition">
+        </span>
       </div>
       <div [ngStyle]="{height: header.isCollapsed ? 0 : header.placeHolderSize + 'px'}"
            class="placeholder"></div>

--- a/projects/ui-framework/src/lib/lists/single-list/single-list.component.scss
+++ b/projects/ui-framework/src/lib/lists/single-list/single-list.component.scss
@@ -153,6 +153,7 @@ $list-max-items: 8;
     margin-right: -10px;
     margin-left: auto;
     visibility: hidden;
+    z-index: 2;
   }
 
   .option-select:hover,

--- a/projects/ui-framework/src/lib/lists/single-list/single-list.component.scss
+++ b/projects/ui-framework/src/lib/lists/single-list/single-list.component.scss
@@ -154,6 +154,7 @@ $list-max-items: 8;
     margin-left: auto;
     visibility: hidden;
     z-index: 2;
+    cursor: default;
   }
 
   .option-select:hover,

--- a/projects/ui-framework/src/lib/lists/single-list/single-list.component.spec.ts
+++ b/projects/ui-framework/src/lib/lists/single-list/single-list.component.spec.ts
@@ -573,4 +573,21 @@ describe('SingleListComponent', () => {
       expect(vScrollWrapperDiv.nativeElement.style.minHeight).toBeTruthy();
     });
   });
+
+  describe('Headers tooltip with description', () => {
+    it('Should have description tooltip', () => {
+      optionsMock[0].description = 'Lorem ipsum';
+      console.log('optionsMock: ', optionsMock);
+      component.ngOnChanges(
+        simpleChange({
+          options: optionsMock,
+          startWithGroupsCollapsed: false,
+        })
+      );
+      fixture.detectChanges();
+      const headerGroups = fixture.debugElement.queryAll(By.css('.headers-group'));
+      const tooltipIcon = headerGroups[0].nativeElement.querySelector('.comp-suffix.has-hover');
+      expect(tooltipIcon).toBeTruthy();
+    });
+  });
 });

--- a/projects/ui-framework/src/lib/lists/single-list/single-list.stories.ts
+++ b/projects/ui-framework/src/lib/lists/single-list/single-list.stories.ts
@@ -87,6 +87,8 @@ const options = cloneDeep(optionsMock);
 
 options[1].options[1].selected = true;
 options[1].options[3].disabled = true;
+options[1].description = 'How I wish, how I wish you were here...';
+options[3].description = 'We are just two lost souls swimming in a fishbowl year after year';
 
 story.add(
   'Single list',


### PR DESCRIPTION
Add tooltip with description for group headers in the single list.
Add description field for `SelectGroupOption` interface.
Add distinct hover state class that doesn't change tooltip icon hover state with its hover state.
Add `z-index` for tooltip icons. It doesn't triggers because of header block's `z-index`.
Add tests.

All changes related to task: https://app.asana.com/0/1159939249943132/1198969695880245/f