### PR TITLE
adjust autocomplete component for google address

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.2.191",
+  "version": "4.2.192",
   "peerDependencies": {
     "@angular/animations": "^10.0.2",
     "@angular/cdk": "^10.0.1",

--- a/projects/ui-framework/src/lib/search/auto-complete/auto-complete-panel/auto-complete-panel.component.spec.ts
+++ b/projects/ui-framework/src/lib/search/auto-complete/auto-complete-panel/auto-complete-panel.component.spec.ts
@@ -21,7 +21,7 @@ describe('AutoCompletePanelComponent', () => {
       return {
         value: `Basic Info E${k} - option`,
         subText: `subtext e${k}`,
-        id: k,
+        id: k.toString(),
       };
     });
 

--- a/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.html
+++ b/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.html
@@ -11,7 +11,7 @@
           [placeholder]="placeholder"
           [hideLabelOnFocus]="hideLabelOnFocus"
           [enableBrowserAutoComplete]="enableBrowserAutoComplete"
-          (searchFocus)="openPanel()"
+          (searchFocus)="onSearchFocus()"
           (searchChange)="onSearchChange($event)">
 </b-search>
 
@@ -21,7 +21,7 @@
 
     <b-auto-complete-panel (optionSelect)="onOptionSelect($event)"
                            [searchValue]="searchValue"
-                           [options]="options"
+                           [options]="filteredOptions"
                            [searchInput]="searchInput">
     </b-auto-complete-panel>
 

--- a/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.html
+++ b/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.html
@@ -11,7 +11,7 @@
           [placeholder]="placeholder"
           [hideLabelOnFocus]="hideLabelOnFocus"
           [enableBrowserAutoComplete]="enableBrowserAutoComplete"
-          (searchFocus)="onSearchFocus()"
+          (searchFocus)="openPanel()"
           (searchChange)="onSearchChange($event)">
 </b-search>
 
@@ -21,7 +21,7 @@
 
     <b-auto-complete-panel (optionSelect)="onOptionSelect($event)"
                            [searchValue]="searchValue"
-                           [options]="filteredOptions"
+                           [options]="options"
                            [searchInput]="searchInput">
     </b-auto-complete-panel>
 

--- a/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.spec.ts
+++ b/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.spec.ts
@@ -38,7 +38,7 @@ describe('AutoCompleteComponent', () => {
       return {
         value: `Basic Info E${k} - option`,
         subText: `subtext e${k}`,
-        id: k,
+        id: k.toString(),
       };
     });
 

--- a/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.spec.ts
+++ b/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.spec.ts
@@ -19,7 +19,6 @@ import { By } from '@angular/platform-browser';
 import { AutoCompletePanelComponent } from './auto-complete-panel/auto-complete-panel.component';
 import { SearchComponent } from '../search/search.component';
 import { SearchModule } from '../search/search.module';
-import { simpleChange } from 'bob-style';
 
 describe('AutoCompleteComponent', () => {
   let component: AutoCompleteComponent;
@@ -195,34 +194,6 @@ describe('AutoCompleteComponent', () => {
       expect(component['panelOpen']).toBe(false);
       expect(component['panelConfig']).toEqual({});
       expect(component['templatePortal']).toBe(null);
-    });
-  });
-
-  describe('skipOptionsFiltering', () => {
-    it('should skip filtering and openPanel on ngOnChanges', () => {
-      spyOn<any>(component, 'openPanel');
-      optionsMock.pop();
-      component.skipOptionsFiltering = true;
-      component.ngOnChanges(simpleChange(
-        {
-          options: optionsMock,
-        },
-        false
-      ));
-      fixture.autoDetectChanges();
-      expect(component['openPanel']).toHaveBeenCalled();
-    });
-    it('should not skipFiltering and not call openPanel', () => {
-      spyOn<any>(component, 'openPanel');
-      optionsMock.pop();
-      component.ngOnChanges(simpleChange(
-        {
-          options: optionsMock,
-          skipOptionsFiltering: false
-        },
-        false
-      ));
-      expect(component['openPanel']).not.toHaveBeenCalled();
     });
   });
 });

--- a/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.spec.ts
+++ b/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.spec.ts
@@ -19,6 +19,7 @@ import { By } from '@angular/platform-browser';
 import { AutoCompletePanelComponent } from './auto-complete-panel/auto-complete-panel.component';
 import { SearchComponent } from '../search/search.component';
 import { SearchModule } from '../search/search.module';
+import { simpleChange } from 'bob-style';
 
 describe('AutoCompleteComponent', () => {
   let component: AutoCompleteComponent;
@@ -194,6 +195,34 @@ describe('AutoCompleteComponent', () => {
       expect(component['panelOpen']).toBe(false);
       expect(component['panelConfig']).toEqual({});
       expect(component['templatePortal']).toBe(null);
+    });
+  });
+
+  describe('skipOptionsFiltering', () => {
+    it('should skip filtering and openPanel on ngOnChanges', () => {
+      spyOn<any>(component, 'openPanel');
+      optionsMock.pop();
+      component.skipOptionsFiltering = true;
+      component.ngOnChanges(simpleChange(
+        {
+          options: optionsMock,
+        },
+        false
+      ));
+      fixture.autoDetectChanges();
+      expect(component['openPanel']).toHaveBeenCalled();
+    });
+    it('should not skipFiltering and not call openPanel', () => {
+      spyOn<any>(component, 'openPanel');
+      optionsMock.pop();
+      component.ngOnChanges(simpleChange(
+        {
+          options: optionsMock,
+          skipOptionsFiltering: false
+        },
+        false
+      ));
+      expect(component['openPanel']).not.toHaveBeenCalled();
     });
   });
 });

--- a/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.ts
+++ b/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.ts
@@ -60,6 +60,7 @@ export class AutoCompleteComponent implements OnChanges, OnDestroy {
     InputAutoCompleteOptions.off;
   @Input() options: AutoCompleteOption[];
   @Input() displayOptionsOnFocus = false;
+  @Input() skipOptionsFiltering = false;
 
   @Output() searchChange: EventEmitter<string> = new EventEmitter<string>();
   @Output() optionSelect: EventEmitter<AutoCompleteOption> = new EventEmitter<
@@ -83,6 +84,7 @@ export class AutoCompleteComponent implements OnChanges, OnDestroy {
     if (has(changes, 'options')) {
       this.options = changes.options.currentValue;
       this.filteredOptions = this.getFilteredOptions();
+      this.ifSkipFiltering();
     }
   }
 
@@ -112,6 +114,13 @@ export class AutoCompleteComponent implements OnChanges, OnDestroy {
 
   ngOnDestroy(): void {
     this.destroyPanel(true);
+  }
+
+  private ifSkipFiltering() {
+    if (this.skipOptionsFiltering && this.options.length) {
+      this.filteredOptions = this.options;
+      this.openPanel();
+    }
   }
 
   private updateFilteredList(): void {

--- a/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.ts
+++ b/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.ts
@@ -83,8 +83,7 @@ export class AutoCompleteComponent implements OnChanges, OnDestroy {
   ngOnChanges(changes: SimpleChanges): void {
     if (has(changes, 'options')) {
       this.options = changes.options.currentValue;
-      this.filteredOptions = this.getFilteredOptions();
-      this.ifSkipFiltering();
+      this.updateFilteredOptions();
     }
   }
 
@@ -116,10 +115,12 @@ export class AutoCompleteComponent implements OnChanges, OnDestroy {
     this.destroyPanel(true);
   }
 
-  private ifSkipFiltering() {
+  private updateFilteredOptions() {
     if (this.skipOptionsFiltering && this.options.length) {
       this.filteredOptions = this.options;
       this.openPanel();
+    } else {
+      this.filteredOptions = this.getFilteredOptions();
     }
   }
 

--- a/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.ts
+++ b/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.ts
@@ -12,7 +12,7 @@ import {
   NgZone,
   ChangeDetectorRef,
 } from '@angular/core';
-import { escapeRegExp, has } from 'lodash';
+import { has } from 'lodash';
 import { PanelPositionService } from '../../popups/panel/panel-position-service/panel-position.service';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { Subscription } from 'rxjs';
@@ -67,7 +67,6 @@ export class AutoCompleteComponent implements OnChanges, OnDestroy {
   >();
 
   searchValue = '';
-  filteredOptions: AutoCompleteOption[];
 
   // Used by ListPanelService:
   private subscribtions: Subscription[] = [];
@@ -82,7 +81,7 @@ export class AutoCompleteComponent implements OnChanges, OnDestroy {
   ngOnChanges(changes: SimpleChanges): void {
     if (has(changes, 'options')) {
       this.options = changes.options.currentValue;
-      this.filteredOptions = this.getFilteredOptions();
+      this.openPanel();
     }
   }
 
@@ -93,15 +92,7 @@ export class AutoCompleteComponent implements OnChanges, OnDestroy {
     } else {
       this.destroyPanel();
     }
-    this.updateFilteredList();
     this.searchChange.emit(this.searchValue);
-  }
-
-  onSearchFocus(): void {
-    if (this.displayOptionsOnFocus) {
-      this.openPanel();
-      this.updateFilteredList();
-    }
   }
 
   onOptionSelect(option: AutoCompleteOption): void {
@@ -114,13 +105,6 @@ export class AutoCompleteComponent implements OnChanges, OnDestroy {
     this.destroyPanel(true);
   }
 
-  private updateFilteredList(): void {
-    this.filteredOptions = this.getFilteredOptions();
-    if (this.filteredOptions.length === 0) {
-      this.destroyPanel();
-    }
-  }
-
   private openPanel(): void {
     if (this.options.length > 0) {
       this.listPanelSrvc.openPanel(this);
@@ -129,13 +113,5 @@ export class AutoCompleteComponent implements OnChanges, OnDestroy {
 
   private destroyPanel(skipEmit = false): void {
     this.listPanelSrvc.destroyPanel(this, skipEmit);
-  }
-
-  private getFilteredOptions(): AutoCompleteOption[] {
-    const matcher = new RegExp(escapeRegExp(this.searchValue), 'i');
-
-    return this.options.filter(
-      (option) => option.value?.match(matcher) || option.subText?.match(matcher)
-    );
   }
 }

--- a/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.ts
+++ b/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.ts
@@ -80,7 +80,7 @@ export class AutoCompleteComponent implements OnInit, OnChanges, OnDestroy {
   private overlayRef: OverlayRef;
   private templatePortal: TemplatePortal;
   public panelOpen = false;
-  private getFilteredOptions: () => AutoCompleteOption[] = this.filterOptions;
+  private getFilteredOptions: () => AutoCompleteOption[] = this.skipFiltering;
 
   ngOnInit(): void {
     this.getFilteredOptions = (this.skipOptionsFiltering) ? this.skipFiltering : this.filterOptions;

--- a/projects/ui-framework/src/lib/search/auto-complete/auto-complete.interface.ts
+++ b/projects/ui-framework/src/lib/search/auto-complete/auto-complete.interface.ts
@@ -1,5 +1,5 @@
 export interface AutoCompleteOption {
   value: string;
   subText?: string;
-  id: string | number;
+  id: string;
 }

--- a/projects/ui-framework/src/lib/search/auto-complete/auto-complete.stories.ts
+++ b/projects/ui-framework/src/lib/search/auto-complete/auto-complete.stories.ts
@@ -57,7 +57,7 @@ const optionsMock: AutoCompleteOption[] = Array.from(Array(20), (_, k) => {
   return {
     value: mockText(randomNumber(2, 5)),
     subText: mockText(randomNumber(2, 5)),
-    id: k
+    id: k.toString()
   };
 });
 


### PR DESCRIPTION
Add filtering skiping for b-auto-complete component in order to show the list as soon as component gets it.
This one will be used for google addresses inputs.

asana task: https://app.asana.com/0/1163700272278026/1199081153195029/f

TODO:
- add story description for `skipOptionsFiltering` Input