### PR TITLE
Custom icon template for side menu

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.2.196",
+  "version": "4.2.197",
   "peerDependencies": {
     "@angular/animations": "^10.0.2",
     "@angular/cdk": "^10.0.1",

--- a/projects/ui-framework/src/lib/navigation/side-menu/side-menu.component.html
+++ b/projects/ui-framework/src/lib/navigation/side-menu/side-menu.component.html
@@ -21,12 +21,32 @@
         'selected': option.id === selectedId && !option.disabled,
         'has-menu': option.actions?.length
       }"
-      class="{{option.icon && !iconTemplate && !option.avatar ? option.icon : null}}"
       [attr.tabindex]="!option.disabled ? 0 : null"
       [attr.role]="!option.disabled ? 'button' : null"
       [attr.data-icon-before-color]="option.id === selectedId && !option.disabled ? iconColor.dark : iconColor.normal">
 
-    <ng-container *ngTemplateOutlet="iconTemplate; context: {$implicit: option, selected: option.id === selectedId && !option.disabled}"></ng-container>
+    <ng-container *ngIf="iconTemplate; else icon">
+      <ng-container
+        *ngTemplateOutlet="
+          iconTemplate;
+          context: {
+            $implicit: option,
+            selected: option.id === selectedId && !option.disabled
+          }
+        "
+      ></ng-container>
+    </ng-container>
+
+    <ng-template #icon>
+      <div
+        class="icon {{
+          option.icon && !iconTemplate && !option.avatar ? option.icon : null
+        }}"
+        [matTooltip]="option.iconTooltip"
+        [matTooltipClass]="option.iconTooltipClass"
+        [matTooltipPosition]="option.iconTooltipPosition || tooltipPosition.above"
+      ></div>
+    </ng-template>
 
     <p class="option-display-name"
        *ngIf="option.displayName && !option.avatar"

--- a/projects/ui-framework/src/lib/navigation/side-menu/side-menu.component.html
+++ b/projects/ui-framework/src/lib/navigation/side-menu/side-menu.component.html
@@ -39,9 +39,8 @@
 
     <ng-template #icon>
       <div
-        class="icon {{
-          option.icon && !iconTemplate && !option.avatar ? option.icon : null
-        }}"
+        *ngIf="option.icon && !iconTemplate && !option.avatar"
+        class="icon {{option.icon}}"
         [matTooltip]="option.iconTooltip"
         [matTooltipClass]="option.iconTooltipClass"
         [matTooltipPosition]="option.iconTooltipPosition || tooltipPosition.above"

--- a/projects/ui-framework/src/lib/navigation/side-menu/side-menu.component.html
+++ b/projects/ui-framework/src/lib/navigation/side-menu/side-menu.component.html
@@ -21,10 +21,12 @@
         'selected': option.id === selectedId && !option.disabled,
         'has-menu': option.actions?.length
       }"
-      class="{{option.icon && !option.avatar ? option.icon : null}}"
+      class="{{option.icon && !iconTemplate && !option.avatar ? option.icon : null}}"
       [attr.tabindex]="!option.disabled ? 0 : null"
       [attr.role]="!option.disabled ? 'button' : null"
       [attr.data-icon-before-color]="option.id === selectedId && !option.disabled ? iconColor.dark : iconColor.normal">
+
+    <ng-container *ngTemplateOutlet="iconTemplate; context: {$implicit: option, selected: option.id === selectedId && !option.disabled}"></ng-container>
 
     <p class="option-display-name"
        *ngIf="option.displayName && !option.avatar"
@@ -33,7 +35,7 @@
        [type]="tooltipType"
        [text]="option.displayName"></p>
 
-    <div *ngIf="option.avatar"
+    <div *ngIf="option.avatar && !iconTemplate"
          class="option-avatar">
       <b-avatar-image class="avatar"
                       [size]="avatarSize.mini"

--- a/projects/ui-framework/src/lib/navigation/side-menu/side-menu.component.html
+++ b/projects/ui-framework/src/lib/navigation/side-menu/side-menu.component.html
@@ -22,8 +22,7 @@
         'has-menu': option.actions?.length
       }"
       [attr.tabindex]="!option.disabled ? 0 : null"
-      [attr.role]="!option.disabled ? 'button' : null"
-      [attr.data-icon-before-color]="option.id === selectedId && !option.disabled ? iconColor.dark : iconColor.normal">
+      [attr.role]="!option.disabled ? 'button' : null">
 
     <ng-container *ngIf="iconTemplate; else icon">
       <ng-container
@@ -44,6 +43,7 @@
         [matTooltip]="option.iconTooltip"
         [matTooltipClass]="option.iconTooltipClass"
         [matTooltipPosition]="option.iconTooltipPosition || tooltipPosition.above"
+        [attr.data-icon-before-color]="option.id === selectedId && !option.disabled ? iconColor.dark : iconColor.normal"
       ></div>
     </ng-template>
 

--- a/projects/ui-framework/src/lib/navigation/side-menu/side-menu.component.scss
+++ b/projects/ui-framework/src/lib/navigation/side-menu/side-menu.component.scss
@@ -90,7 +90,7 @@ $side-menu-selected-border: 4px;
 
 // Icon
 
-.menu-option:before {
+.icon:before {
   margin-right: 8px;
 }
 

--- a/projects/ui-framework/src/lib/navigation/side-menu/side-menu.component.ts
+++ b/projects/ui-framework/src/lib/navigation/side-menu/side-menu.component.ts
@@ -19,7 +19,7 @@ import { isKey } from '../../services/utils/functional-utils';
 import { Keys } from '../../enums';
 import { AvatarSize } from '../../avatar/avatar/avatar.enum';
 import { TruncateTooltipType } from '../../popups/truncate-tooltip/truncate-tooltip.enum';
-import { TooltipClass } from '../../popups/tooltip/tooltip.enum';
+import { TooltipClass, TooltipPosition } from '../../popups/tooltip/tooltip.enum';
 
 @Component({
   selector: 'b-side-menu',
@@ -48,6 +48,7 @@ export class SideMenuComponent implements OnChanges {
   readonly buttonType = ButtonType;
   readonly avatarSize = AvatarSize;
   readonly tooltipClass = TooltipClass;
+  readonly tooltipPosition = TooltipPosition;
 
   public focusedId: number | string;
 

--- a/projects/ui-framework/src/lib/navigation/side-menu/side-menu.component.ts
+++ b/projects/ui-framework/src/lib/navigation/side-menu/side-menu.component.ts
@@ -8,6 +8,8 @@ import {
   OnChanges,
   HostBinding,
   NgZone,
+  TemplateRef,
+  ContentChild
 } from '@angular/core';
 import { Icons, IconColor, IconSize } from '../../icons/icons.enum';
 import { ButtonType } from '../../buttons/buttons.enum';
@@ -32,6 +34,7 @@ export class SideMenuComponent implements OnChanges {
     private cd: ChangeDetectorRef
   ) {}
 
+  @ContentChild(TemplateRef) iconTemplate;
   @HostBinding('attr.role') role = 'navigation';
 
   @Input() options: SideMenuOption[];

--- a/projects/ui-framework/src/lib/navigation/side-menu/side-menu.interface.ts
+++ b/projects/ui-framework/src/lib/navigation/side-menu/side-menu.interface.ts
@@ -3,6 +3,7 @@ import { Avatar } from '../../avatar/avatar/avatar.interface';
 import { MenuItem } from '../menu/menu.interface';
 import { IconPosition } from '../../typography/label-value/label-value.enum';
 import { TooltipClass } from '../../popups/tooltip/tooltip.enum';
+import { TooltipPosition } from '@angular/material/tooltip';
 
 export interface SideMenuOptionAvatar extends Avatar {
   textIcon?: Icons;
@@ -14,6 +15,9 @@ export interface SideMenuOption {
   id: number | string;
   displayName?: string;
   icon?: Icons;
+  iconTooltip?: string;
+  iconTooltipClass?: TooltipClass | TooltipClass[];
+  iconTooltipPosition?: TooltipPosition;
   avatar?: SideMenuOptionAvatar;
   actions?: MenuItem[];
   disabled?: boolean;

--- a/projects/ui-framework/src/lib/navigation/side-menu/side-menu.mock.ts
+++ b/projects/ui-framework/src/lib/navigation/side-menu/side-menu.mock.ts
@@ -23,6 +23,7 @@ export const sideMenuMock1: SideMenuOption[] = makeArray(4).map((i, index) => ({
   id: index,
   displayName: mockText(1),
   icon: Icons.folder,
+  iconTooltip: index === 0 ? 'Tooltip only in first item' : null,
   actions: menuMock,
 }));
 

--- a/projects/ui-framework/src/lib/navigation/side-menu/side-menu.module.ts
+++ b/projects/ui-framework/src/lib/navigation/side-menu/side-menu.module.ts
@@ -7,6 +7,7 @@ import { TruncateTooltipModule } from '../../popups/truncate-tooltip/truncate-to
 import { EventManagerPlugins } from '../../services/utils/eventManager.plugins';
 import { AvatarModule } from '../../avatar/avatar/avatar.module';
 import { IconsModule } from '../../icons/icons.module';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
   declarations: [SideMenuComponent],
@@ -17,6 +18,7 @@ import { IconsModule } from '../../icons/icons.module';
     ButtonsModule,
     AvatarModule,
     IconsModule,
+    MatTooltipModule,
   ],
   exports: [SideMenuComponent],
   providers: [EventManagerPlugins[0]],

--- a/projects/ui-framework/src/lib/navigation/side-menu/side-menu.stories.ts
+++ b/projects/ui-framework/src/lib/navigation/side-menu/side-menu.stories.ts
@@ -16,10 +16,11 @@ import { IconsModule } from '../../icons/icons.module';
 import { sideMenuMock1, sideMenuMock2 } from './side-menu.mock';
 import { ButtonsModule } from '../../../lib/buttons/buttons.module';
 import { SideMenuOption } from './side-menu.interface';
-import { Icons } from '../../icons/icons.enum';
+import { IconColor, Icons, IconSize } from '../../icons/icons.enum';
 import { ButtonType } from '../../buttons/buttons.enum';
 import { select } from '@storybook/addon-knobs';
 import { TruncateTooltipType } from '../../popups/truncate-tooltip/truncate-tooltip.enum';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 const story = storiesOf(ComponentGroupType.Navigation, module)
   .addDecorator(withNotes)
@@ -66,6 +67,30 @@ const storyTemplate = `
         <b-square-button [icon]="icons.download"
                         [type]="buttonType.tertiary">
         </b-square-button>
+    </b-side-menu>
+
+  </div>
+
+  <hr style="width: 100%; margin: 60px 0 50px 0; border: 0; height: 0; border-top: 2px dashed #d2d2d2;">
+
+  <div style="max-width: 300px;">
+
+    <b-side-menu [options]="menuWithIcons"
+                [headerLabel]="headerLabel || 'Menu with custom icon template'"
+                [selectedId]="selectedId"
+                [tooltipType]="tooltipType"
+                (selectOption)="selectOption($event)">
+        <b-square-button [icon]="icons.download"
+                        [type]="buttonType.tertiary">
+        </b-square-button>
+        <ng-template let-option let-selected="selected">
+          <b-icon style="margin-right: 8px;"
+                  [matTooltip]="'Custom tooltip'"
+                  [icon]="icons.folder"
+                  [size]="iconSize.large"
+                  [color]="selected ? iconColor.dark : iconColor.normal">
+          </b-icon>
+        </ng-template>
     </b-side-menu>
 
   </div>
@@ -180,6 +205,8 @@ story.add(
       template: storyTemplate,
       props: {
         icons: Icons,
+        iconSize: IconSize,
+        iconColor: IconColor,
         buttonType: ButtonType,
         headerLabel: text('headerLabel', '', 'Props'),
         menuWithIcons: object<SideMenuOption[]>(
@@ -209,6 +236,7 @@ story.add(
           StoryBookLayoutModule,
           IconsModule,
           ButtonsModule,
+          MatTooltipModule,
         ],
       },
     };


### PR DESCRIPTION
![Screenshot_39](https://user-images.githubusercontent.com/3210598/98793610-cd74e980-2410-11eb-9c4f-65d5609d9be5.png)

https://www.figma.com/file/SjH4fRPr0yGhvu8MwBDv0o/Docs?node-id=138%3A941

1. Added support for custom template outlet in order to support custom icons
2. Added support for icon tooltip in side menu 