### PR TITLE
b-search removes whitespaces as user types in. bugfix

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.2.195",
+  "version": "4.2.196",
   "peerDependencies": {
     "@angular/animations": "^10.0.2",
     "@angular/cdk": "^10.0.1",

--- a/projects/ui-framework/src/lib/search/search/search.component.spec.ts
+++ b/projects/ui-framework/src/lib/search/search/search.component.spec.ts
@@ -98,4 +98,17 @@ describe('SearchComponent', () => {
       expect(component.value).toBe('');
     }));
   });
+
+  describe('onInput', () => {
+    it('should emmit only trimmed values', fakeAsync(() => {
+      const inputElement = fixture.debugElement.query(By.css('input'));
+      inputElement.nativeElement.value = '         some untrimmed string   ';
+      inputElement.nativeElement.dispatchEvent(new Event('input'));
+
+      tick(300);
+      fixture.detectChanges();
+
+      expect(component.searchChange.emit).toHaveBeenCalledWith('some untrimmed string');
+    }));
+  });
 });

--- a/projects/ui-framework/src/lib/search/search/search.component.spec.ts
+++ b/projects/ui-framework/src/lib/search/search/search.component.spec.ts
@@ -108,6 +108,7 @@ describe('SearchComponent', () => {
       tick(300);
       fixture.detectChanges();
 
+      expect(component.value).toEqual(inputElement.nativeElement.value);
       expect(component.searchChange.emit).toHaveBeenCalledWith('some untrimmed string');
     }));
   });

--- a/projects/ui-framework/src/lib/search/search/search.component.ts
+++ b/projects/ui-framework/src/lib/search/search/search.component.ts
@@ -102,10 +102,10 @@ export class SearchComponent implements OnChanges, OnInit, OnDestroy {
   }
 
   onInput(event: DOMInputEvent): void {
-    const newValue = event.target.value.trim();
+    const newValue = event.target.value;
     if (this.value !== newValue) {
       this.value = newValue;
-      this.searchChange.emit(this.value);
+      this.searchChange.emit(this.value.trim());
     }
   }
 


### PR DESCRIPTION
Make b-search component to emit only trimmed value, but internally assign to itself untrimmed value.
Add tests.