### PR TITLE
AutocompleteComponent. Eliminate redundant checks

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.2.235",
+  "version": "4.2.236",
   "peerDependencies": {
     "@angular/animations": "^10.0.2",
     "@angular/cdk": "^10.0.1",

--- a/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.ts
+++ b/projects/ui-framework/src/lib/search/auto-complete/auto-complete.component.ts
@@ -81,20 +81,28 @@ export class AutoCompleteComponent implements OnInit, OnChanges, OnDestroy {
   private templatePortal: TemplatePortal;
   public panelOpen = false;
   private getFilteredOptions: () => AutoCompleteOption[] = this.skipFiltering;
+  private changeOptionsFlow: (changes: SimpleChanges) => void = this.changeOptions;
 
   ngOnInit(): void {
     this.getFilteredOptions = (this.skipOptionsFiltering) ? this.skipFiltering : this.filterOptions;
+    this.changeOptionsFlow = (this.skipOptionsFiltering) ? this.changeOptionsAndOpenPanel : this.changeOptions;
   }
 
 
   ngOnChanges(changes: SimpleChanges): void {
     if (has(changes, 'options')) {
-      this.options = changes.options.currentValue;
-      this.filteredOptions = this.getFilteredOptions();
-      if (this.skipOptionsFiltering) {
-        this.openPanel();
-      }
+      this.changeOptionsFlow(changes);
     }
+  }
+
+  private changeOptions(changes: SimpleChanges) {
+    this.options = changes.options.currentValue;
+    this.filteredOptions = this.getFilteredOptions();
+  }
+
+  private changeOptionsAndOpenPanel(changes: SimpleChanges) {
+    this.changeOptions(changes);
+    this.openPanel();
   }
 
   onSearchChange(searchVal: string): void {


### PR DESCRIPTION
Add a logic to check whether or not to openPanel on the options change inside ngOnChanges hook.
Check it inside the ngOnInit to escape further checks in ngOnChanges hook.