### PR TITLE
Miki/change chevron to triangle

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.2.231",
+  "version": "4.2.232",
   "peerDependencies": {
     "@angular/animations": "^10.0.2",
     "@angular/cdk": "^10.0.1",

--- a/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.html
+++ b/projects/ui-framework/src/lib/layout/collapsible-section/collapsible-section.component.html
@@ -11,7 +11,7 @@
           [attr.data-collapsible]="!!collapsible"
           [attr.aria-controls]="(collapsible && panelID) || null"
           [attr.aria-expanded]="!collapsible ? null : !!expanded"
-          [attr.data-icon-before]="!collapsible ? null : expanded ? 'chevron-down' : 'chevron-right'"
+          [attr.data-icon-before]="!collapsible ? null : expanded ? 'arrow-drop-down' : 'arrow-drop-right'"
           (click)="togglePanel()">
 
     <div *ngIf="title"

--- a/projects/ui-framework/src/lib/lists/multi-list/multi-list.component.html
+++ b/projects/ui-framework/src/lib/lists/multi-list/multi-list.component.html
@@ -39,8 +39,8 @@
         <span *ngIf="options.length > 1 && !header.groupIsOption"
               class="chevron b-icon-medium"
               [ngClass]="{
-                'b-icon-chevron-down': !header.isCollapsed,
-                'b-icon-chevron-right': header.isCollapsed
+                'b-icon-arrow-drop-down': !header.isCollapsed,
+                'b-icon-arrow-drop-right': header.isCollapsed
               }"></span>
         <div class="header-option">
           <span *ngIf="header.hasCheckbox && !readonly"


### PR DESCRIPTION
Replaced chevron 2 states icon in lists and collapsible section into a triangle variant