### PR TITLE
Replace PagerService

### DIFF
--- a/projects/ui-framework/src/lib/navigation/pager/pager.component.ts
+++ b/projects/ui-framework/src/lib/navigation/pager/pager.component.ts
@@ -23,6 +23,7 @@ import { PagerService } from './pager.service';
   selector: 'b-pager',
   templateUrl: './pager.component.html',
   styleUrls: ['./pager.component.scss'],
+  providers: [PagerService]
 })
 export class PagerComponent<T = any> implements OnInit {
   constructor(private zone: NgZone, private pagerService: PagerService) {}

--- a/projects/ui-framework/src/lib/navigation/pager/pager.module.ts
+++ b/projects/ui-framework/src/lib/navigation/pager/pager.module.ts
@@ -4,13 +4,12 @@ import { PagerComponent } from './pager.component';
 import { ButtonsModule } from '../../buttons/buttons.module';
 import { SingleSelectModule } from '../../lists/single-select/single-select.module';
 import { EventManagerPlugins } from '../../services/utils/eventManager.plugins';
-import { PagerService } from './pager.service';
 import { TranslateModule } from '@ngx-translate/core';
 
 @NgModule({
   imports: [CommonModule, ButtonsModule, SingleSelectModule, TranslateModule],
   declarations: [PagerComponent],
   exports: [PagerComponent],
-  providers: [EventManagerPlugins[0], PagerService],
+  providers: [EventManagerPlugins[0]],
 })
 export class PagerModule {}


### PR DESCRIPTION
Replace PagerService in order to avoid 'null provider' errors when it is used in the dialogs or lightboxes.

<img width="923" alt="Screen Shot 2021-01-05 at 13 31 52" src="https://user-images.githubusercontent.com/17579177/103652791-49e8fc00-4f6c-11eb-8ce4-6fe379427261.png">
