### PR TITLE
corrected attribute selector to select

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.3.88",
+  "version": "4.3.89",
   "peerDependencies": {
     "@angular/animations": "^11.0.5",
     "@angular/cdk": "^11.0.3",

--- a/projects/ui-framework/src/lib/indicators/empty-state/empty-state.component.html
+++ b/projects/ui-framework/src/lib/indicators/empty-state/empty-state.component.html
@@ -4,7 +4,7 @@
      border="0"
      alt="">
 
-<ng-content selector="[top]"></ng-content>
+<ng-content select="[top]"></ng-content>
 
 <b-icon *ngIf="config?.icon && !config.imgSrc"
         class="empty-state-icon"
@@ -23,4 +23,4 @@
           [type]="buttonType"
           [size]="buttonSize">{{config.buttonLabel}}</b-button>
 
-<ng-content selector="[bottom]"></ng-content>
+<ng-content select="[bottom]"></ng-content>


### PR DESCRIPTION
relates https://app.asana.com/0/1199338258160982/1200035905766237/f


Corrected a mistake in an attribute name, causing the ng-content slot to not work:
Original: `<ng-content selector="[top]"></ng-content>`
New: `<ng-content select="[top]"></ng-content>`