### PR TITLE
Fix cursor bug on color picker

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.3.136",
+  "version": "4.3.137",
   "peerDependencies": {
     "@angular/animations": "^11.0.5",
     "@angular/cdk": "^11.0.3",

--- a/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.html
+++ b/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.html
@@ -53,6 +53,7 @@
   <div class="b-select-panel color-picker-dropdown">
     <span
       [cpToggle]="true"
+      [cpWidth]="colorPickerWidth"
       [cpOutputFormat]="'hex'"
       [cpDialogDisplay]="'inline'"
       [colorPicker]="value"

--- a/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.scss
+++ b/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.scss
@@ -58,7 +58,6 @@
 
 ::ng-deep {
   .cdk-overlay-container .color-picker-dropdown .color-picker {
-    width: #{$b-select-panel-min-width - 2px} !important;
     border: none;
     border-radius: $border-radius;
     margin: 0 auto;

--- a/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.ts
+++ b/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.ts
@@ -48,7 +48,6 @@ export class ColorPickerComponent extends BaseFormElement implements OnDestroy, 
     this.baseValue = '';
     this.wrapEvent = false;
   }
-  // test
 
   @ViewChild(CdkOverlayOrigin, { static: true }) overlayOrigin: CdkOverlayOrigin;
   @ViewChild('templateRef', { static: true }) templateRef: TemplateRef<any>;
@@ -59,6 +58,7 @@ export class ColorPickerComponent extends BaseFormElement implements OnDestroy, 
   public panelClassList: string[] = ['b-select-panel'];
   public positionClassList: OverlayPositionClasses = {};
   public readonly defaultValue = COLOR_PICKER_DEFAULT;
+  public readonly colorPickerWidth = '278'; // scss $b-select-panel-min-width - 2px
 
   public get overlayRef(): OverlayRef {
     return this.panel?.overlayRef;


### PR DESCRIPTION
There is a bug due to the need of the color-picker to know the actual container width in order to calculate the cursor position properly.
Current flow in the prod is that it's defining this width through css, that's why it causes this missleading cursor position behaviour.

<img width="540" alt="Screenshot 2021-04-12 at 10 49 46" src="https://user-images.githubusercontent.com/17579177/114359855-12967680-9b7d-11eb-8f1d-51f0efb599cc.png">
