### PR TITLE
Pavel/ more work on color-picker

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.3.151",
+  "version": "4.3.152",
   "peerDependencies": {
     "@angular/animations": "^11.0.5",
     "@angular/cdk": "^11.0.3",

--- a/projects/ui-framework/src/lib/cards/card/card.stories.ts
+++ b/projects/ui-framework/src/lib/cards/card/card.stories.ts
@@ -1,27 +1,26 @@
-import { storiesOf } from '@storybook/angular';
-import { withKnobs } from '@storybook/addon-knobs';
-import { ComponentGroupType } from '../../consts';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { withKnobs } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/angular';
+
+import { ComponentGroupType } from '../../consts';
 import { StoryBookLayoutModule } from '../../story-book-layout/story-book-layout.module';
-import { CardExampleModule } from './card-example.module';
 import { CardsModule } from '../cards.module';
+import { CardExampleModule } from './card-example.module';
 
 const story = storiesOf(ComponentGroupType.Cards, module).addDecorator(
   withKnobs
 );
 
-const template = `
-<b-card [card]="cardData"
+const template = `<b-card [card]="cardData"
         [type]="type"
         (clicked)="cardClickHandler($event)">
-  <div card-top>
-     ...card top - ng-content
-  </div>
-  <div card-content>
-    ...card content - ng-content
-  </div>
-</b-card>
-`;
+    <div card-top>
+      ...card top - ng-content
+    </div>
+    <div card-content>
+      ...card content - ng-content
+    </div>
+</b-card>`;
 
 const storyTemplate = `
 <b-story-book-layout [title]="'Single Card'">
@@ -84,6 +83,14 @@ const note = `
   --- | --- | --- | ---
   [type] | CardType | Card theme | primary
   [card] | Card | card contents data | &nbsp;
+  [isClickable] | boolean | makes the card focusable and adds hover state | false
+  (clicked) | EventEmitter | emits on footer CTA click
+
+  **Note:**
+  The (clicked) event of the Card emits, when the user clicks the CTA in the footer (for which you need to pass label as card.footerCtaLabel).<br>
+  To make the <u>whole card</u> clickable, you need:
+  - use (click) listener instead of (clicked)
+  - pass [isClickable]="true"
 
   #### Card interface
   ~~~

--- a/projects/ui-framework/src/lib/form-elements/base-form-element.ts
+++ b/projects/ui-framework/src/lib/form-elements/base-form-element.ts
@@ -177,7 +177,8 @@ export abstract class BaseFormElement
 
   public writeValue(
     value: any,
-    forceElementValue: ForceElementValue = this.forceElementValue
+    forceElementValue: ForceElementValue = this.forceElementValue,
+    ...args: any[]
   ): void {
     this.writingValue = true;
 
@@ -205,9 +206,12 @@ export abstract class BaseFormElement
         this.input?.nativeElement?.nodeName.toUpperCase()
       )
     ) {
-      this.input.nativeElement.value = isFunction(forceElementValue)
-        ? forceElementValue(this.value)
+      const newInputValue = isFunction(forceElementValue)
+        ? forceElementValue(this.value, ...args)
         : this.value;
+
+      this.input.nativeElement.value !== newInputValue &&
+        (this.input.nativeElement.value = newInputValue);
     }
 
     this.writingValue = false;

--- a/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.html
+++ b/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.html
@@ -8,6 +8,7 @@
 <div cdkOverlayOrigin
      class="bfe-wrap has-prefix"
      [ngClass]="{
+       'has-suffix': config?.showClearButton!==false && config?.showFooter===false,
        focused: panelOpen,
        'panel-open': panelOpen,
        'panel-above': positionClassList['panel-above'],
@@ -25,17 +26,18 @@
          class="bfe-input"
          [attr.id]="id"
          [attr.name]="id"
-         [type]="'text'"
+         type="text"
+         maxlength="7"
          [attr.placeholder]="hideLabelOnFocus && label ? (!required ? label :
          label + '*') : placeholder"
-         [value]="value"
          [attr.disabled]="disabled || readonly || null"
          [required]="required"
          [readonly]="readonly"
-         [attr.maxlength]="7"
+         (blur)="isTyping=false"
          (input)="onInputChange($event)">
 
-  <span [hidden]="!value || readonly"
+  <span *ngIf="config?.showClearButton!==false && config?.showFooter===false"
+        [hidden]="!value || readonly"
         class="bfe-suffix">
     <b-icon class="clear-input"
             role="button"
@@ -62,7 +64,19 @@
           [cpWidth]="(colorPickerWidth||280)-2"
           [cpOutputFormat]="'hex'"
           [cpDialogDisplay]="'inline'"
+          (cpSliderDragStart)="isTyping=false"
           (colorPickerChange)="onColorPickerChange($event)"
-          (colorPickerClose)="onColorPickerChange($event)"></span>
+          (colorPickerClose)="colorPickerClose($event)"></span>
+
+    <b-list-footer #footer
+                   *ngIf="config?.showFooter !== false"
+                   [listActionsState]="listActionsState"
+                   [size]="size"
+                   (apply)="onApply()"
+                   (cancel)="onCancel()"
+                   (clear)="clearInput()">
+      <ng-content footerAction
+                  select="[footerAction],[footerActionRight]"></ng-content>
+    </b-list-footer>
   </div>
 </ng-template>

--- a/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.html
+++ b/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.html
@@ -8,8 +8,9 @@
 <div cdkOverlayOrigin
      class="bfe-wrap has-prefix"
      [ngClass]="{
-       'has-suffix': config?.showClearButton!==false && config?.showFooter===false,
+       'has-suffix': config?.showClearButton!==false,
        focused: panelOpen,
+       'hide-clear': panelOpen && config?.showFooter!==false,
        'panel-open': panelOpen,
        'panel-above': positionClassList['panel-above'],
        'panel-below': positionClassList['panel-below']
@@ -36,7 +37,7 @@
          (blur)="isTyping=false"
          (input)="onInputChange($event)">
 
-  <span *ngIf="config?.showClearButton!==false && config?.showFooter===false"
+  <span *ngIf="config?.showClearButton!==false"
         [hidden]="!value || readonly"
         class="bfe-suffix">
     <b-icon class="clear-input"

--- a/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.scss
+++ b/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.scss
@@ -31,7 +31,7 @@
 
 .color-circle {
   border-radius: 50%;
-  box-shadow: inset 0 0 0 1px var(--avatar-border-color, $border-color);
+  box-shadow: inset 0 0 0 1px var(--circle-border-color, $border-color);
   @include size(map-get($avatarSizes, mini)-4px);
   margin-left: -8px;
   pointer-events: none;
@@ -62,11 +62,11 @@
     }
 
     .saturation-lightness .cursor {
-      border-color: var(--cursor-color, $grey-800);
+      border-color: var(--cursor-border-color, $grey-800);
     }
 
     .selected-color {
-      border-color: var(--avatar-border-color, $border-color);
+      border-color: var(--circle-border-color, $border-color);
     }
 
     .color-picker {

--- a/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.scss
+++ b/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.scss
@@ -1,7 +1,5 @@
 @import '../../style/common-imports';
-@import '../../style/panels';
-@import '../../style/variables';
-@import '../../style/typography';
+@import '../../avatar/avatar/avatar.mixin';
 
 @include bFormElement();
 
@@ -29,19 +27,24 @@
 
 .color-circle {
   border-radius: 50%;
-  height: 24px;
-  width: 24px;
-  box-shadow: 0 0 0 1px $border-color;
+  box-shadow: inset 0 0 0 1px var(--avatar-border-color, $border-color);
+  @include size(map-get($avatarSizes, mini)-4px);
+  margin-left: -8px;
+  pointer-events: none;
+}
 
-  &.default-value {
-    box-shadow: none;
-    background-image: linear-gradient($grey-700, $grey-700),
-      linear-gradient($negative-600, $negative-600),
-      linear-gradient(#d38865, #d38865), linear-gradient(#7d273f, #7d273f);
-    background-size: 50% 50%;
-    background-position: left top, right top, left bottom, right bottom;
-    background-repeat: no-repeat;
-  }
+:host[data-size='smaller'] .color-circle {
+  @include size(map-get($avatarSizes, micro));
+}
+
+.default-value {
+  box-shadow: none;
+  background-image: linear-gradient($grey-700, $grey-700),
+    linear-gradient($negative-600, $negative-600),
+    linear-gradient(#d38865, #d38865), linear-gradient(#7d273f, #7d273f);
+  background-size: 50% 50%;
+  background-position: left top, right top, left bottom, right bottom;
+  background-repeat: no-repeat;
 }
 
 ::ng-deep {
@@ -52,6 +55,14 @@
 
     .saturation-lightness {
       box-shadow: black(0.3) -1px 0px 0px 0px, black(0.6) 1px 0px 0px 0px;
+    }
+
+    .saturation-lightness .cursor {
+      border-color: var(--cursor-color, $grey-800);
+    }
+
+    .selected-color {
+      border-color: var(--avatar-border-color, $border-color);
     }
 
     .color-picker {

--- a/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.scss
+++ b/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.scss
@@ -25,6 +25,10 @@
   opacity: 1;
 }
 
+.bfe-wrap.hide-clear .clear-input {
+  opacity: 0;
+}
+
 .color-circle {
   border-radius: 50%;
   box-shadow: inset 0 0 0 1px var(--avatar-border-color, $border-color);

--- a/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.ts
+++ b/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.component.ts
@@ -240,15 +240,15 @@ export class ColorPickerComponent extends BaseFormElement
       : ColorsGrey.color_grey_800;
 
     setCssProps(this.hostElRef.nativeElement, {
-      '--avatar-border-color': avatarBorderColor,
+      '--circle-border-color': avatarBorderColor,
     });
 
     this.panel &&
       setCssProps(
         this.panel.overlayRef.overlayElement.children[0] as HTMLElement,
         {
-          '--avatar-border-color': avatarBorderColor,
-          '--cursor-color': cursorColor,
+          '--circle-border-color': avatarBorderColor,
+          '--cursor-border-color': cursorColor,
         }
       );
   }

--- a/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.const.ts
+++ b/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.const.ts
@@ -1,1 +1,3 @@
 export const COLOR_PICKER_DEFAULT = 'Default';
+
+export const HEX_REGEX = /^#(?:[0-9a-fA-F]{3}){1,2}$/i;

--- a/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.interface.ts
+++ b/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.interface.ts
@@ -1,0 +1,5 @@
+export interface ColorPickerConfig {
+  emitOnChange?: boolean;
+  showClearButton?: boolean;
+  showFooter?: boolean;
+}

--- a/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.module.ts
+++ b/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.module.ts
@@ -5,6 +5,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { IconsModule } from '../../icons/icons.module';
+import { ListFooterModule } from '../../lists/list-footer/list-footer.module';
 import { FormElementLabelModule } from '../form-element-label/form-element-label.module';
 import { InputMessageModule } from '../input-message/input-message.module';
 import { ColorPickerComponent } from './color-picker.component';
@@ -17,6 +18,7 @@ import { ColorPickerComponent } from './color-picker.component';
     InputMessageModule,
     OverlayModule,
     IconsModule,
+    ListFooterModule,
   ],
   exports: [ColorPickerComponent],
   declarations: [ColorPickerComponent],

--- a/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.stories.ts
+++ b/projects/ui-framework/src/lib/form-elements/color-picker/color-picker.stories.ts
@@ -1,6 +1,6 @@
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { action } from '@storybook/addon-actions';
-import { select, withKnobs } from '@storybook/addon-knobs';
+import { boolean, select, withKnobs } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/angular';
 
 import { ComponentGroupType } from '../../consts';
@@ -17,6 +17,11 @@ const story = storiesOf(ComponentGroupType.FormElements, module).addDecorator(
 );
 
 const template = `<b-colorpicker
+      [config]="{
+        emitOnChange: emitOnChange,
+        showClearButton: showClearButton,
+        showFooter: showFooter
+      }"
       [value]="value"
       [label]="label"
       [placeholder]="placeholder"
@@ -50,6 +55,11 @@ const note = `
 
   *Note*: Component supports only HEX color format.
 
+  #### Properties
+  Name | Type | Description | Defaults
+  --- | --- | --- | ---
+  [config] | ColorPickerConfig | emitOnChange, showClearButton, showFooter;<br> emitOnChange and showClearButton are only relevant if showFooter is false | showFooter:&nbsp;true,<br> showClearButton:&nbsp;true,<br> emitOnChange:&nbsp;false
+
   ${formElemsPropsDoc}
 `;
 story.add(
@@ -71,6 +81,11 @@ story.add(
           ],
           ''
         ),
+
+        emitOnChange: boolean('emitOnChange', false),
+        showClearButton: boolean('showClearButton', true),
+        showFooter: boolean('showFooter', true),
+
         ...FormElementsCommonProps('Pick a color', COLOR_PICKER_DEFAULT),
 
         size: select(

--- a/projects/ui-framework/src/lib/lists/single-select/single-select.component.scss
+++ b/projects/ui-framework/src/lib/lists/single-select/single-select.component.scss
@@ -35,7 +35,7 @@
   .bfe-prefix > b-avatar-image,
   .bfe-prefix > b-employees-showcase,
   .bfe-prefix > b-avatar-showcase {
-    margin-left: -12px;
+    margin-left: -10px;
     pointer-events: none;
   }
 

--- a/projects/ui-framework/src/lib/services/color-service/color.service.ts
+++ b/projects/ui-framework/src/lib/services/color-service/color.service.ts
@@ -41,7 +41,7 @@ export class ColorService {
       color = this.parseToRGB(color);
     }
     const brightness = this.getBrightness(color);
-    return brightness && brightness < sensitivity; // 128
+    return brightness < sensitivity; // 128
   }
 
   public randomColor(): string {

--- a/projects/ui-framework/src/lib/services/utils/transformers.ts
+++ b/projects/ui-framework/src/lib/services/utils/transformers.ts
@@ -157,6 +157,11 @@ export const selectValueMultiOrSingle = (
     : value;
 };
 
+export const hexifyColor = (color: string): string => {
+  color = color?.replace(/#|[^#0-9a-fA-F]/gi, '');
+  return color && `#${color}`;
+};
+
 // -------------------------------
 // Typecheckers
 // -------------------------------
@@ -341,12 +346,7 @@ export const valueInArrayOrFail = <T = any>(
 // Helpers
 // -------------------------------
 
-export const logValue = <T = any>(value: T): T => {
-  console.log(value);
-  return value;
-};
-
-export const logValueComment = <T = any>(comment: string) => (value: T): T => {
-  console.log(comment + ': ', value);
+export const logValue = <T = any>(tag?: string) => (value: T): T => {
+  log.inf(isString(value) ? `"${value}"` : stringify(value), tag);
   return value;
 };

--- a/projects/ui-framework/src/public_api.ts
+++ b/projects/ui-framework/src/public_api.ts
@@ -367,9 +367,10 @@ export {
 } from './lib/form-elements/radio-button/radio-button.enum';
 export * from './lib/form-elements/radio-button/radio-button.interface';
 // Colorpicker
+export * from './lib/form-elements/color-picker/color-picker.interface';
+export * from './lib/form-elements/color-picker/color-picker.const';
 export { ColorPickerModule } from './lib/form-elements/color-picker/color-picker.module';
 export { ColorPickerComponent } from './lib/form-elements/color-picker/color-picker.component';
-export { COLOR_PICKER_DEFAULT } from './lib/form-elements/color-picker/color-picker.const';
 
 
 /*


### PR DESCRIPTION
- refactored write/transmit value code
- added footer (can be disabled)
- more validation, like not allowing characters that are not valid for hex colors (like letters after F)

<table><tr><td>
<img width="341" alt="CleanShot 2021-04-27 at 14 48 54@2x" src="https://user-images.githubusercontent.com/2077754/116236469-c72cbc80-a767-11eb-8948-2f91be36ddce.png">
</td><td>
<img width="333" alt="CleanShot 2021-04-27 at 14 49 15@2x" src="https://user-images.githubusercontent.com/2077754/116236482-cac04380-a767-11eb-8e87-f825809c574c.png">
</td></tr></table>
