### PR TITLE
Eyalko/add more real-estate for avatar on b-ee-layout component

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.3.241",
+  "version": "4.3.242",
   "peerDependencies": {
     "@angular/animations": "^11.0.5",
     "@angular/cdk": "^11.0.3",

--- a/projects/ui-framework/src/lib/layout/ee-layout/ee-layout.component.html
+++ b/projects/ui-framework/src/lib/layout/ee-layout/ee-layout.component.html
@@ -13,7 +13,7 @@
 
     <div class="bel-navigation-container" *ngIf="avatar">
       <b-round-button *ngIf="showPrev"
-                      class="bel-nav-button-prev"
+                      class="bel-nav-button bel-nav-button-prev"
                       type="tertiary"
                       [matTooltip]="tooltipPrev"
                       [disabled]="disablePrev"
@@ -27,7 +27,7 @@
                 [orientation]="avatarOrientation.vertical"></b-avatar>
 
       <b-round-button *ngIf="showNext"
-                      class="bel-nav-button-next"
+                      class="bel-nav-button bel-nav-button-next"
                       type="tertiary"
                       [matTooltip]="tooltipNext"
                       [disabled]="disableNext"

--- a/projects/ui-framework/src/lib/layout/ee-layout/ee-layout.component.scss
+++ b/projects/ui-framework/src/lib/layout/ee-layout/ee-layout.component.scss
@@ -47,7 +47,7 @@ $ee-layout-nav-button-size: $button-size-medium;
 }
 
 .bel-avatar {
-  grid-column: 2/3;
+  grid-column: 1/4;
   grid-row: 1/4;
 }
 

--- a/projects/ui-framework/src/lib/layout/ee-layout/ee-layout.component.scss
+++ b/projects/ui-framework/src/lib/layout/ee-layout/ee-layout.component.scss
@@ -37,7 +37,7 @@ $ee-layout-nav-button-size: $button-size-medium;
 }
 
 .bel-nav-button {
-  // stack it on top of the avatar just case as they overlap on the grid cells
+  // stack it on top of the avatar just in case as they overlap on the grid cells
   position: relative;
 }
 

--- a/projects/ui-framework/src/lib/layout/ee-layout/ee-layout.component.scss
+++ b/projects/ui-framework/src/lib/layout/ee-layout/ee-layout.component.scss
@@ -36,6 +36,11 @@ $ee-layout-nav-button-size: $button-size-medium;
   align-items: start;
 }
 
+.bel-nav-button {
+  // stack it on top of the avatar just case as they overlap on the grid cells
+  position: relative;
+}
+
 .bel-nav-button-prev {
   grid-column: 1/2;
   grid-row: 2/3;

--- a/projects/ui-framework/src/lib/layout/ee-layout/ee-layout.stories.ts
+++ b/projects/ui-framework/src/lib/layout/ee-layout/ee-layout.stories.ts
@@ -263,6 +263,8 @@ const note = `
   [disablePrev] | boolean | true will disable the prev button, false will enable it. The default is false.
   [tooltipNext] | string | The tooltip strings that will be added to the next button. There is no tooltip by default.
   [tooltipPrev] | string | The tooltip strings that will be added to the previous buttons. There is no tooltip by default.
+  (prevClicked) | EventEmitter<MouseEvent> | event that is fired when clicking the prev button.
+  (nextClicked) | EventEmitter<MouseEvent> | event that is fired when clicking the next button.
 
   #### interface: EELayoutConfig
   Name | Type | Description

--- a/projects/ui-framework/src/lib/layout/ee-layout/ee-layout.stories.ts
+++ b/projects/ui-framework/src/lib/layout/ee-layout/ee-layout.stories.ts
@@ -263,8 +263,8 @@ const note = `
   [disablePrev] | boolean | true will disable the prev button, false will enable it. The default is false.
   [tooltipNext] | string | The tooltip strings that will be added to the next button. There is no tooltip by default.
   [tooltipPrev] | string | The tooltip strings that will be added to the previous buttons. There is no tooltip by default.
-  (prevClicked) | EventEmitter<MouseEvent> | event that is fired when clicking the prev button.
-  (nextClicked) | EventEmitter<MouseEvent> | event that is fired when clicking the next button.
+  (prevClicked) | EventEmitter&lt;MouseEvent&gt; | event that is fired when clicking the prev button.
+  (nextClicked) | EventEmitter&lt;MouseEvent&gt; | event that is fired when clicking the next button.
 
   #### interface: EELayoutConfig
   Name | Type | Description

--- a/projects/ui-framework/src/lib/popups/lightbox/lightbox-example.module.ts
+++ b/projects/ui-framework/src/lib/popups/lightbox/lightbox-example.module.ts
@@ -25,6 +25,7 @@ export class LightboxExampleComponent implements OnDestroy {
   @Input() fillScreen = false;
   @Input() closeOnBackdropClick = false;
   @Input() disableClose = false;
+  @Input() disableCloseButton = false;
 
   private lightbox: LightboxData;
 
@@ -33,6 +34,7 @@ export class LightboxExampleComponent implements OnDestroy {
       fillScreen: this.fillScreen,
       closeOnBackdropClick: this.closeOnBackdropClick,
       disableClose: this.disableClose,
+      disableCloseButton: this.disableCloseButton,
 
       ...(this.showInLightbox === 'image' &&
         this.imageLink && {

--- a/projects/ui-framework/src/lib/popups/lightbox/lightbox.component.html
+++ b/projects/ui-framework/src/lib/popups/lightbox/lightbox.component.html
@@ -1,4 +1,5 @@
-<b-square-button (clicked)="closeLightbox()"
+<b-square-button *ngIf="!config.disableCloseButton"
+                 (clicked)="closeLightbox()"
                  [type]="buttons.tertiary"
                  [icon]="icons.close"
                  [color]="iconColor.white"

--- a/projects/ui-framework/src/lib/popups/lightbox/lightbox.interface.ts
+++ b/projects/ui-framework/src/lib/popups/lightbox/lightbox.interface.ts
@@ -12,6 +12,7 @@ export interface LightboxConfig {
   iframe?: string | SafeResourceUrl;
   fillScreen?: boolean;
   disableClose?: boolean;
+  disableCloseButton?: boolean;
   closeOnBackdropClick?: boolean;
 }
 

--- a/projects/ui-framework/src/lib/popups/lightbox/lightbox.service.ts
+++ b/projects/ui-framework/src/lib/popups/lightbox/lightbox.service.ts
@@ -99,13 +99,11 @@ export class LightboxService {
 
       this.subs.push(
         merge(
-          config.closeOnBackdropClick === true &&
-            config.disableClose !== true &&
-            config.disableCloseButton !== true
+          config.closeOnBackdropClick === true && config.disableClose !== true
             ? fromEvent(this.lightbox.overlayRef.overlayElement, 'click')
             : EMPTY,
 
-          config.disableClose !== true && config.disableCloseButton !== true
+          config.disableClose !== true
             ? this.utilsService
                 .getWindowKeydownEvent(true)
                 .pipe(filterKey(Keys.escape), insideZone(this.zone))

--- a/projects/ui-framework/src/lib/popups/lightbox/lightbox.service.ts
+++ b/projects/ui-framework/src/lib/popups/lightbox/lightbox.service.ts
@@ -99,11 +99,13 @@ export class LightboxService {
 
       this.subs.push(
         merge(
-          config.closeOnBackdropClick === true && config.disableClose !== true
+          config.closeOnBackdropClick === true &&
+            config.disableClose !== true &&
+            config.disableCloseButton !== true
             ? fromEvent(this.lightbox.overlayRef.overlayElement, 'click')
             : EMPTY,
 
-          config.disableClose !== true
+          config.disableClose !== true && config.disableCloseButton !== true
             ? this.utilsService
                 .getWindowKeydownEvent(true)
                 .pipe(filterKey(Keys.escape), insideZone(this.zone))

--- a/projects/ui-framework/src/lib/popups/lightbox/lightbox.stories.ts
+++ b/projects/ui-framework/src/lib/popups/lightbox/lightbox.stories.ts
@@ -17,6 +17,7 @@ const storyTemplate = `<b-story-book-layout [title]="'Lightbox'">
                   [showInLightbox]="showInLightbox"
                   [fillScreen]="fillScreen"
                   [disableClose]="disableClose"
+                  [disableCloseButton]="disableCloseButton"
                   [closeOnBackdropClick]="closeOnBackdropClick">
                 </b-lightbox-example>
 </b-story-book-layout>`;
@@ -98,6 +99,7 @@ story.add(
         ),
         fillScreen: boolean('fillScreen', false),
         disableClose: boolean('disableClose', false),
+        disableCloseButton: boolean('disableCloseButton', false),
         closeOnBackdropClick: boolean('closeOnBackdropClick', false),
       },
       moduleMetadata: {

--- a/projects/ui-framework/src/lib/popups/lightbox/lightbox.stories.ts
+++ b/projects/ui-framework/src/lib/popups/lightbox/lightbox.stories.ts
@@ -37,6 +37,7 @@ const note = `
   video | string | embedable youtube or vimeo link to show in lightbox (other URLs will throw error)
   fillScreen | boolean | if content should fill most of the screen (may be important for components)
   disableClose | boolean | if true, closing via Escape key and backdrop click will be disabled (only closing via X button is enabled) | false
+  disableCloseButton | boolean | if true removes the close button at the top right | false
   closeOnBackdropClick | boolean | if backdrop click should close lightbox | false
 
   #### Returned object properties


### PR DESCRIPTION
relates https://app.asana.com/0/1159939249943132/1200279780148686/f
relates https://app.asana.com/0/1197220482257394/1200129143279644/f

description made the avatar span across the whole width of the sidebar so there will be more room for the name. Added support to disable the close button on lighbox (at the top right) to allow more control.

instead of:
![image](https://user-images.githubusercontent.com/305776/120504582-1ecad300-c379-11eb-9f6c-9b5bf9c922a5.png)

have this:
![image](https://user-images.githubusercontent.com/305776/120504457-0064d780-c379-11eb-98a6-a8de61e05474.png)

