### PR TITLE
hideIcon input added to SearchComponent

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.3.267",
+  "version": "4.3.268",
   "peerDependencies": {
     "@angular/animations": "^11.0.5",
     "@angular/cdk": "^11.0.3",

--- a/projects/ui-framework/src/lib/search/search/search.component.html
+++ b/projects/ui-framework/src/lib/search/search/search.component.html
@@ -2,11 +2,12 @@
        class="bfe-label"
        [attr.for]="id">{{label}}</label>
 
-<div class="bfe-wrap has-prefix has-suffix"
-     [ngClass]="{focused: inputFocused}"
+<div class="bfe-wrap has-suffix"
+     [ngClass]="{focused: inputFocused, 'has-prefix': !hideIcon}"
      (click.outside-zone)="input.focus()">
 
-  <b-icon class="bfe-prefix input-icon"
+  <b-icon *ngIf="!hideIcon"
+          class="bfe-prefix input-icon"
           [config]="searchIcn"
           [color]="!inputFocused ? iconColor.normal : iconColor.dark">
   </b-icon>

--- a/projects/ui-framework/src/lib/search/search/search.component.spec.ts
+++ b/projects/ui-framework/src/lib/search/search/search.component.spec.ts
@@ -128,14 +128,14 @@ describe('SearchComponent', () => {
     it('should not have class has-prefix', () => {
       component.hideIcon = true;
       fixture.detectChanges();
-      const inputIconElement = fixture.debugElement.query(By.css('.bfe-wrap'));
-      expect(inputIconElement.classes['has-prefix']).toBeFalsy();
+      const bfeWrapElement = fixture.debugElement.query(By.css('.bfe-wrap'));
+      expect(bfeWrapElement.classes['has-prefix']).toBeFalsy();
     });
     it('should have class has-prefix', () => {
       component.hideIcon = false;
       fixture.detectChanges();
-      const inputIconElement = fixture.debugElement.query(By.css('.bfe-wrap'));
-      expect(inputIconElement.classes['has-prefix']).toBeTruthy();
+      const bfeWrapElement = fixture.debugElement.query(By.css('.bfe-wrap'));
+      expect(bfeWrapElement.classes['has-prefix']).toBeTruthy();
     });
   });
 });

--- a/projects/ui-framework/src/lib/search/search/search.component.spec.ts
+++ b/projects/ui-framework/src/lib/search/search/search.component.spec.ts
@@ -106,4 +106,36 @@ describe('SearchComponent', () => {
       expect(component.searchChange.emit).toHaveBeenCalledWith('some untrimmed string');
     }));
   });
+
+  describe('hideIcon', () => {
+    it('should show icon by default', () => {
+      const inputIconElement = fixture.debugElement.query(By.css('.input-icon'));
+      fixture.detectChanges();
+      expect(inputIconElement).toBeTruthy();
+    });
+    it('should hide icon', () => {
+      component.hideIcon = true;
+      fixture.detectChanges();
+      const inputIconElement = fixture.debugElement.query(By.css('.input-icon'));
+      expect(inputIconElement).toBeNull();
+    });
+    it('should show icon', () => {
+      component.hideIcon = false;
+      fixture.detectChanges();
+      const inputIconElement = fixture.debugElement.query(By.css('.input-icon'));
+      expect(inputIconElement).toBeTruthy();
+    });
+    it('should not have class has-prefix', () => {
+      component.hideIcon = true;
+      fixture.detectChanges();
+      const inputIconElement = fixture.debugElement.query(By.css('.bfe-wrap'));
+      expect(inputIconElement.classes['has-prefix']).toBeFalsy();
+    });
+    it('should have class has-prefix', () => {
+      component.hideIcon = false;
+      fixture.detectChanges();
+      const inputIconElement = fixture.debugElement.query(By.css('.bfe-wrap'));
+      expect(inputIconElement.classes['has-prefix']).toBeTruthy();
+    });
+  });
 });

--- a/projects/ui-framework/src/lib/search/search/search.component.ts
+++ b/projects/ui-framework/src/lib/search/search/search.component.ts
@@ -48,6 +48,7 @@ export class SearchComponent implements OnChanges, OnInit, OnDestroy {
 
   @Input() config: SearchConfig;
 
+  @Input() hideIcon = false;
   @Input() hideLabelOnFocus = true;
   @Input() enableBrowserAutoComplete: InputAutoCompleteOptions =
     InputAutoCompleteOptions.off;

--- a/projects/ui-framework/src/lib/search/search/search.stories.ts
+++ b/projects/ui-framework/src/lib/search/search/search.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/angular';
-import { text, withKnobs } from '@storybook/addon-knobs';
+import { boolean, text, withKnobs } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { SearchModule } from './search.module';
 import { ComponentGroupType } from '../../consts';
@@ -17,6 +17,7 @@ const template = `
           [label]="label"
           [placeholder]="placeholder"
           [size]="size"
+          [hideIcon]="hideIcon"
           (searchChange)="searchChange($event)"
           (searchFocus)="searchFocus($event)">
 </b-search>
@@ -45,6 +46,7 @@ const note = `
   [hideLabelOnFocus] | boolean | make label behave as placeholder | true
   [enableBrowserAutoComplete] | InputAutoCompleteOptions | enable/disable autocomplete | off
   [size] | FormElementSize | regular height (44px), smaller height (36px) | regular
+  [hideIcon] | boolean | hide the search icon | false
   (searchFocus) | EventEmitter<wbr>&lt;string&gt;  | emits on input focus | &nbsp;
   (searchChange) | EventEmitter<wbr>&lt;string&gt;  | emits on input value change | &nbsp;
 
@@ -61,6 +63,7 @@ story.add(
         value: text('value', ''),
         label: text('label', ''),
         placeholder: text('placeholder', 'Search'),
+        hideIcon: boolean('hideIcon', false),
         searchChange: action('searchChange'),
         searchFocus: action('searchFocus'),
         size: select(


### PR DESCRIPTION
Hiding search icon capability on SearchComponent, then can be used in AutoCompleteComponent.

![image](https://user-images.githubusercontent.com/44846094/121352204-47cd0400-c935-11eb-9bde-2f0d07ec4f5f.png)

![image](https://user-images.githubusercontent.com/44846094/121352338-6d5a0d80-c935-11eb-8181-5c6b99b3075c.png)

Related: https://app.asana.com/0/1159573723793308/1200430778018352