### PR TITLE
Pager for API usage

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.3.273",
+  "version": "4.3.274",
   "peerDependencies": {
     "@angular/animations": "^11.0.5",
     "@angular/cdk": "^11.0.3",

--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.3.277",
+  "version": "4.3.278",
   "peerDependencies": {
     "@angular/animations": "^11.0.5",
     "@angular/cdk": "^11.0.3",

--- a/projects/ui-framework/src/lib/navigation/pager/pager.component.ts
+++ b/projects/ui-framework/src/lib/navigation/pager/pager.component.ts
@@ -220,7 +220,7 @@ export class PagerComponent<T = any> implements OnInit {
     this.stateChange.emit({
       currentPage: this.currentPage,
       sliceSize: this.config.sliceSize,
-      slice: this.getCurrentSlice(),
+      currentSlice: this.getCurrentSlice(),
       offset: this.currentPage * this.config.sliceSize
     });
   }

--- a/projects/ui-framework/src/lib/navigation/pager/pager.component.ts
+++ b/projects/ui-framework/src/lib/navigation/pager/pager.component.ts
@@ -21,7 +21,7 @@ import {
 } from '../../services/utils/functional-utils';
 import { DOMMouseEvent } from '../../types';
 import { PAGER_CONFIG_DEF } from './pager.const';
-import { PagerConfig } from './pager.interface';
+import { PagerConfig, PagerState } from './pager.interface';
 import { PagerService } from './pager.service';
 
 @Component({
@@ -84,6 +84,7 @@ export class PagerComponent<T = any> implements OnInit {
   @Output() sliceChange: EventEmitter<number[] | T[]> = new EventEmitter();
   @Output() pageChange: EventEmitter<number> = new EventEmitter();
   @Output() sliceSizeChange: EventEmitter<number> = new EventEmitter();
+  @Output() stateChange: EventEmitter<PagerState> = new EventEmitter();
 
   public totalItems: number;
   public totalPages: number;
@@ -138,9 +139,12 @@ export class PagerComponent<T = any> implements OnInit {
     this.config.sliceSize = value.selectedIDs[0] as number;
     this.totalPages = Math.ceil(this.totalItems / this.config.sliceSize);
 
-    const newPage = Math.floor(currentSliceStart / this.config.sliceSize);
+    const newPage =
+      this.config.resetToFirstPage === true
+        ? 0
+        : Math.floor(currentSliceStart / this.config.sliceSize);
 
-    this.changePage(newPage);
+    this.changePage(newPage, false);
     this.emitChange('slicesize');
   }
 
@@ -210,8 +214,15 @@ export class PagerComponent<T = any> implements OnInit {
       );
     }
     if (which === 'slicesize') {
+      this.pageChange.emit(this.currentPage);
       this.sliceSizeChange.emit(this.config.sliceSize);
     }
+
+    this.stateChange.emit({
+      page: this.currentPage,
+      limit: this.config.sliceSize,
+      offset: this.currentPage * this.config.sliceSize
+    });
   }
 
   public pageButtonsTrackBy(index: number, page: number): number {

--- a/projects/ui-framework/src/lib/navigation/pager/pager.interface.ts
+++ b/projects/ui-framework/src/lib/navigation/pager/pager.interface.ts
@@ -3,4 +3,11 @@ export interface PagerConfig {
   sliceMax: number;
   sliceSize: number;
   showSliceSizeSelect?: boolean;
+  resetToFirstPage?: boolean;
+}
+
+export interface PagerState {
+  page: number;
+  limit: number;
+  offset: number;
 }

--- a/projects/ui-framework/src/lib/navigation/pager/pager.interface.ts
+++ b/projects/ui-framework/src/lib/navigation/pager/pager.interface.ts
@@ -3,11 +3,12 @@ export interface PagerConfig {
   sliceMax: number;
   sliceSize: number;
   showSliceSizeSelect?: boolean;
-  resetToFirstPage?: boolean;
+  resetOnSliceSizeChange?: boolean;
 }
 
-export interface PagerState {
-  page: number;
-  limit: number;
+export interface PagerState<T = any> {
+  currentPage: number;
+  sliceSize: number;
+  slice: number[] | T[];
   offset: number;
 }

--- a/projects/ui-framework/src/lib/navigation/pager/pager.interface.ts
+++ b/projects/ui-framework/src/lib/navigation/pager/pager.interface.ts
@@ -9,6 +9,6 @@ export interface PagerConfig {
 export interface PagerState<T = any> {
   currentPage: number;
   sliceSize: number;
-  slice: number[] | T[];
+  currentSlice: number[] | T[];
   offset: number;
 }

--- a/projects/ui-framework/src/lib/navigation/pager/pager.stories.ts
+++ b/projects/ui-framework/src/lib/navigation/pager/pager.stories.ts
@@ -22,6 +22,7 @@ const templateForNotes = `<b-pager  [items]="items"
             [config]="config"
             (pageChange)="onPageChange($event)"
             (sliceChange)="onSliceChange($event)"
+            (stateChange)="onStateChange($event)"
             (sliceSizeChange)="onSliceSizeChange($event)">
 </b-pager>`;
 
@@ -42,10 +43,12 @@ const storyTemplate = `
                   sliceStep: config.sliceStep,
                   sliceMax: config.sliceMax,
                   sliceSize: config.sliceSize,
-                  showSliceSizeSelect: showSliceSizeSelect
+                  showSliceSizeSelect: showSliceSizeSelect,
+                  resetToFirstPage: resetToFirstPage
                 }"
                 (pageChange)="onPageChange($event)"
                 (sliceChange)="onSliceChange($event)"
+                (stateChange)="onStateChange($event)"
                 (sliceSizeChange)="onSliceSizeChange($event)">
     </b-pager>
   </div>
@@ -73,6 +76,7 @@ const note = `
   (sliceChange) |  EventEmitter<wbr>&lt;number[] / any[]&gt; | if a number was provided for [items] (that is considered to be your items array length), the output emits current slice indexes;<br>\
   if you provided your data array as [items], the output emits a slice of your data array ('current page items') | &nbsp;
   (sliceSizeChange) | number | emits on slice size change (from the Select) | &nbsp;
+  (stateChange) | PagerState | combination of currentPage, limit, offset (API usage) | &nbsp;
 
   --------------------------------
 
@@ -113,13 +117,20 @@ const note = `
         (sliceChange)="currentSlice = $event"></b-pager>
   ~~~
 
-
-  #### interface: PagerConfig
+  #### interface: PagerState
   Name | Type | Description
   --- | --- | ---
-  sliceSize | number | current items per page
-  sliceMax | number | max items per page
-  sliceStep | number | items per page step for items-per-page Select
+  page | number | current page
+  limit | number | limit (API usage)
+  offset | number | offset (API usage)
+
+  #### interface: PagerConfig
+  Name | Type | Description | Default
+  --- | --- | --- | ---
+  sliceSize | number | current items per page | &nbsp;
+  sliceMax | number | max items per page | &nbsp;
+  sliceStep | number | items per page step for items-per-page Select | &nbsp;
+  resetToFirstPage | boolean | should reset to first page on slice size change | false
 
   #### const: PAGER<sub>-</sub>CONFIG<sub>-</sub>DEF
   ~~~
@@ -174,10 +185,12 @@ story.add(
         }),
 
         showSliceSizeSelect: boolean('showSliceSizeSelect', true),
+        resetToFirstPage: boolean('resetToFirstPage', false),
 
         onSliceChange: action('sliceChange'),
         onPageChange: action('pageChange'),
         onSliceSizeChange: action('sliceSizeChange'),
+        onStateChange: action('stateChange'),
       },
       moduleMetadata: {
         imports: [

--- a/projects/ui-framework/src/lib/navigation/pager/pager.stories.ts
+++ b/projects/ui-framework/src/lib/navigation/pager/pager.stories.ts
@@ -44,7 +44,7 @@ const storyTemplate = `
                   sliceMax: config.sliceMax,
                   sliceSize: config.sliceSize,
                   showSliceSizeSelect: showSliceSizeSelect,
-                  resetToFirstPage: resetToFirstPage
+                  resetOnSliceSizeChange: resetOnSliceSizeChange
                 }"
                 (pageChange)="onPageChange($event)"
                 (sliceChange)="onSliceChange($event)"
@@ -76,7 +76,7 @@ const note = `
   (sliceChange) |  EventEmitter<wbr>&lt;number[] / any[]&gt; | if a number was provided for [items] (that is considered to be your items array length), the output emits current slice indexes;<br>\
   if you provided your data array as [items], the output emits a slice of your data array ('current page items') | &nbsp;
   (sliceSizeChange) | number | emits on slice size change (from the Select) | &nbsp;
-  (stateChange) | PagerState | combination of currentPage, limit, offset (API usage) | &nbsp;
+  (stateChange) | PagerState | combination of currentPage, slice, sliceSize, offset | &nbsp;
 
   --------------------------------
 
@@ -120,8 +120,9 @@ const note = `
   #### interface: PagerState
   Name | Type | Description
   --- | --- | ---
-  page | number | current page
-  limit | number | limit (API usage)
+  currentPage | number | current page
+  slice | number[] | current slice [start inclusive index, end exclusive index]
+  sliceSize | number | current slice size; limit (API usage)
   offset | number | offset (API usage)
 
   #### interface: PagerConfig
@@ -130,7 +131,7 @@ const note = `
   sliceSize | number | current items per page | &nbsp;
   sliceMax | number | max items per page | &nbsp;
   sliceStep | number | items per page step for items-per-page Select | &nbsp;
-  resetToFirstPage | boolean | should reset to first page on slice size change | false
+  resetOnSliceSizeChange | boolean | should reset to first page on slice size change | false
 
   #### const: PAGER<sub>-</sub>CONFIG<sub>-</sub>DEF
   ~~~
@@ -185,7 +186,7 @@ story.add(
         }),
 
         showSliceSizeSelect: boolean('showSliceSizeSelect', true),
-        resetToFirstPage: boolean('resetToFirstPage', false),
+        resetOnSliceSizeChange: boolean('resetOnSliceSizeChange', false),
 
         onSliceChange: action('sliceChange'),
         onPageChange: action('pageChange'),

--- a/projects/ui-framework/src/lib/navigation/pager/pager.stories.ts
+++ b/projects/ui-framework/src/lib/navigation/pager/pager.stories.ts
@@ -121,7 +121,7 @@ const note = `
   Name | Type | Description
   --- | --- | ---
   currentPage | number | current page
-  slice | number[] | current slice [start inclusive index, end exclusive index]
+  currentSlice | number[] | current slice [start inclusive index, end exclusive index]
   sliceSize | number | current slice size; limit (API usage)
   offset | number | offset (API usage)
 


### PR DESCRIPTION
Fixing 2 problems:
1. If using for the API, `pageChange` & `sliceSizeChange` events are doubling API requests)
2. Added optional `resetToFirstPage` config param (when changing the slice size, navigate to the first page)