### PR TITLE
Info strip - add fullWidth prop

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.3.275",
+  "version": "4.3.276",
   "peerDependencies": {
     "@angular/animations": "^11.0.5",
     "@angular/cdk": "^11.0.3",

--- a/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.html
+++ b/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.html
@@ -5,7 +5,7 @@
 
 <div class="flx content flx-grow"
      [ngClass]="fullWidth
-        ? 'flx-row flx-row-align-y full_width'
+        ? 'flx-row flx-row-align-y full-width'
         : 'flx-col flx-col-align-y'">
   <p *ngIf="text"
      class="mrg-0 pre-wrap"
@@ -16,5 +16,5 @@
   <b-link *ngIf="link"
           [config]="link"
           (clicked)="linkClicked.emit()"
-          [ngClass]="fullWidth && 'mrg-l-8'"></b-link>
+          [class.mrg-l-8]="fullWidth"></b-link>
 </div>

--- a/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.html
+++ b/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.html
@@ -3,7 +3,10 @@
         [size]="iconSize">
 </b-icon>
 
-<div class="content flx-col flx-grow flx-col-align-y">
+<div class="flx content flx-grow"
+     [ngClass]="fullWidth
+        ? 'flx-row flx-row-align-y full_width'
+        : 'flx-col flx-col-align-y'">
   <p *ngIf="text"
      class="mrg-0 pre-wrap"
      [innerHTML]="text"></p>
@@ -12,5 +15,6 @@
 
   <b-link *ngIf="link"
           [config]="link"
-          (clicked)="linkClicked.emit()"></b-link>
+          (clicked)="linkClicked.emit()"
+          [ngClass]="fullWidth && 'mrg-l-8'"></b-link>
 </div>

--- a/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.scss
+++ b/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.scss
@@ -7,11 +7,11 @@
 
   display: flex;
 
-  &[full-width='false'] {
+  &[data-full-width='false'] {
     border-radius: $border-radius;
   }
 
-  .full_width {
+  .full-width {
     justify-content: flex-start;
   }
   &[data-type='warning'] {

--- a/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.scss
+++ b/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.scss
@@ -8,6 +8,10 @@
   border-radius: $border-radius;
   display: flex;
 
+  .full_width {
+    border-radius: 0;
+    justify-content: flex-start;
+  }
   &[data-type='warning'] {
     background-color: rgba($color-warn, 0.1);
     color: $color3_darker;

--- a/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.scss
+++ b/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.scss
@@ -5,11 +5,13 @@
   text-align: left;
   padding: 10px;
 
-  border-radius: $border-radius;
   display: flex;
 
+  &[full-width='false'] {
+    border-radius: $border-radius;
+  }
+
   .full_width {
-    border-radius: 0;
     justify-content: flex-start;
   }
   &[data-type='warning'] {

--- a/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.ts
+++ b/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.ts
@@ -1,9 +1,5 @@
 import {
-  Component,
-  EventEmitter,
-  HostBinding,
-  Input,
-  Output,
+  Component, EventEmitter, HostBinding, Input, Output
 } from '@angular/core';
 
 import { Icon } from '../../icons/icon.interface';
@@ -17,15 +13,18 @@ import { InfoStripIconSize, InfoStripIconType } from './info-strip.enum';
   styleUrls: ['./info-strip.component.scss'],
 })
 export class InfoStripComponent {
+
   @HostBinding('attr.data-type') @Input() iconType: InfoStripIconType =
     InfoStripIconType.information;
 
   @Input() link: Link;
   @Input() text: string;
+  @Input() fullWidth: boolean;
   @Input() iconSize: InfoStripIconSize = InfoStripIconSize.large;
 
   @Output() linkClicked: EventEmitter<void> = new EventEmitter();
 
   readonly iconSizes = InfoStripIconSize;
   readonly iconsDic: Record<InfoStripIconType, Icon> = INFOSTRIP_ICON_DICT;
+
 }

--- a/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.ts
+++ b/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.ts
@@ -1,5 +1,9 @@
 import {
-  Component, EventEmitter, HostBinding, Input, Output
+  Component,
+  EventEmitter,
+  HostBinding,
+  Input,
+  Output
 } from '@angular/core';
 
 import { Icon } from '../../icons/icon.interface';
@@ -13,7 +17,6 @@ import { InfoStripIconSize, InfoStripIconType } from './info-strip.enum';
   styleUrls: ['./info-strip.component.scss'],
 })
 export class InfoStripComponent {
-
   @HostBinding('attr.data-type') @Input() iconType: InfoStripIconType =
     InfoStripIconType.information;
 
@@ -26,5 +29,4 @@ export class InfoStripComponent {
 
   readonly iconSizes = InfoStripIconSize;
   readonly iconsDic: Record<InfoStripIconType, Icon> = INFOSTRIP_ICON_DICT;
-
 }

--- a/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.ts
+++ b/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.ts
@@ -19,10 +19,10 @@ import { InfoStripIconSize, InfoStripIconType } from './info-strip.enum';
 export class InfoStripComponent {
   @HostBinding('attr.data-type') @Input() iconType: InfoStripIconType =
     InfoStripIconType.information;
+  @HostBinding('attr.full-width') @Input() fullWidth = false;
 
   @Input() link: Link;
   @Input() text: string;
-  @Input() fullWidth: boolean;
   @Input() iconSize: InfoStripIconSize = InfoStripIconSize.large;
 
   @Output() linkClicked: EventEmitter<void> = new EventEmitter();

--- a/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.ts
+++ b/projects/ui-framework/src/lib/indicators/info-strip/info-strip.component.ts
@@ -19,7 +19,7 @@ import { InfoStripIconSize, InfoStripIconType } from './info-strip.enum';
 export class InfoStripComponent {
   @HostBinding('attr.data-type') @Input() iconType: InfoStripIconType =
     InfoStripIconType.information;
-  @HostBinding('attr.full-width') @Input() fullWidth = false;
+  @HostBinding('attr.data-full-width') @Input() fullWidth = false;
 
   @Input() link: Link;
   @Input() text: string;

--- a/projects/ui-framework/src/lib/indicators/info-strip/info-strip.stories.ts
+++ b/projects/ui-framework/src/lib/indicators/info-strip/info-strip.stories.ts
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { object, select, text, withKnobs } from '@storybook/addon-knobs';
+import { boolean, object, select, text, withKnobs } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/angular';
 
 import { ComponentGroupType } from '../../consts';
@@ -17,15 +17,17 @@ const template = `<b-info-strip
         [iconType]="iconType"
         [iconSize]="iconSize"
         [link]="link"
+        [fullWidth]="fullWidth"
         [text]="text"
         (linkClicked)="onLinkClick()">
 </b-info-strip>`;
 
 const template2 = `<b-info-strip
+        [fullWidth]="fullWidth"
         [iconType]="infoStripIconType.warning"
         [iconSize]="infoStripIconSize.normal"
         [text]="'Please agree with everything I say'">
-    <b-checkbox [label]="'I agree with everything you say'" class="mrg-t-8"></b-checkbox>
+    <b-checkbox [label]="'I agree with everything you say'" [ngClass]="fullWidth ? 'mrg-l-8' : 'mrg-t-8'"></b-checkbox>
 </b-info-strip>`;
 
 const storyTemplate = `<b-story-book-layout [title]="'Info Strip'">
@@ -79,6 +81,7 @@ story.add(
           InfoStripIconSize.large
         ),
         text: text('text', 'Place your info text here'),
+        fullWidth: boolean('fullWidth', false),
         link: object('link', {
           text: 'Click here',
           url: 'https://app.hibob.com',


### PR DESCRIPTION
Closes https://app.asana.com/0/1199672671179462/1200451982344589/f

We need it for the new Employee Acknowledgement feature. ([Figma link](https://www.figma.com/file/6FecfMlTJMAZjHrfdaTGSm/My-Reviews?node-id=545%3A9265))

![Screen Shot 2021-06-13 at 10 36 46](https://user-images.githubusercontent.com/81902739/121800630-c11d6d00-cc3b-11eb-9fc1-fdd2e338ba65.png)
![Screen Shot 2021-06-13 at 10 36 50](https://user-images.githubusercontent.com/81902739/121800634-c24e9a00-cc3b-11eb-99d2-861dc0bda0e6.png)

After radius fix:
![Screen Shot 2021-06-13 at 11 50 22](https://user-images.githubusercontent.com/81902739/121800992-93392800-cc3d-11eb-83ef-cef794093310.png)
