### PR TITLE
Horizontal layout last-item slot fix

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.3.296",
+  "version": "4.3.297",
   "peerDependencies": {
     "@angular/animations": "^11.0.5",
     "@angular/cdk": "^11.0.3",

--- a/projects/ui-framework/src/lib/layout/widget-box/horizontal-layout/horizontal-layout.component.ts
+++ b/projects/ui-framework/src/lib/layout/widget-box/horizontal-layout/horizontal-layout.component.ts
@@ -2,6 +2,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import {
+  AfterContentInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -25,13 +26,13 @@ import { ContentTemplateConsumer } from '../../../services/utils/contentTemplate
 })
 export class HorizontalLayoutComponent
   extends ContentTemplateConsumer
-  implements OnDestroy {
+  implements OnDestroy, AfterContentInit {
   showAll: boolean;
   itemsPerRow: number;
 
   @Input() items: any[];
   @Input() cardWidth: number;
-  @Input() swiper: boolean = false;
+  @Input() swiper = false;
   @ViewChild(CardsLayoutComponent, { static: true })
   private cardsLayout: CardsLayoutComponent;
 
@@ -62,7 +63,7 @@ export class HorizontalLayoutComponent
   }
 
   private get hasLastItem(): boolean {
-    return !!this.lastItem.nativeElement.childNodes.length;
+    return !!this.lastItem.nativeElement.children.length;
   }
 
   private setItemsPerRow(): void {


### PR DESCRIPTION
- use children in order to avoid boolean decision depending on text-nodes and comments
- add missing interface
- remove redundant type