### PR TITLE
Added skipUndefined param to InputObservable decorator

### DIFF
--- a/projects/ui-framework/package.json
+++ b/projects/ui-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bob-style",
-  "version": "4.3.302",
+  "version": "4.3.303",
   "peerDependencies": {
     "@angular/animations": "^11.0.5",
     "@angular/cdk": "^11.0.3",

--- a/projects/ui-framework/src/lib/services/utils/decorators.ts
+++ b/projects/ui-framework/src/lib/services/utils/decorators.ts
@@ -45,7 +45,8 @@ export function InputSubject<T = any>(
 */
 export function InputObservable<T = any>(
   defaultValue: T = undefined,
-  operators: Operator<any, T>[] = [pass]
+  operators: Operator<any, T>[] = [pass],
+  skipUndefinedValue = true,
 ) {
   const subjectSymbol = Symbol();
   const subjectSymbolObservable = Symbol();
@@ -57,7 +58,10 @@ export function InputObservable<T = any>(
           this[subjectSymbol] = new BehaviorSubject<T>(defaultValue);
           this[subjectSymbolObservable] = this[subjectSymbol].asObservable();
         }
-        if (value !== undefined && value !== this[subjectSymbol].getValue()) {
+        if (skipUndefinedValue && value === undefined) {
+          return;
+        }
+        if (value !== this[subjectSymbol].getValue()) {
           this[subjectSymbol].next(value);
         }
       },


### PR DESCRIPTION
This will allow passing `undefined` values to the input observable decorator

My specific case is to display the preloader, can't use `null`, it has a meaningful value